### PR TITLE
Fix socket draw arg for Blender 4.0

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -6,7 +6,7 @@ class SceneSocket(NodeSocket):
     bl_label = "Scene"
 
     def draw(self, context, layout, node, text):
-        layout.label(text)
+        layout.label(text=text)
 
     def draw_color(self, context, node):
         return (0.8, 0.8, 0.2, 1.0)


### PR DESCRIPTION
## Summary
- ensure socket label uses keyword arg when drawing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1a2df0c88330bafe1f9499cd9243