### PR TITLE
Fix missing scene tree error

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -90,8 +90,15 @@ def _evaluate_node(node):
 
 
 def evaluate_scene_tree(tree):
-    """Traverse *tree*, resolve dependencies and evaluate each node."""
-    order = _topological_sort(tree.nodes)
+    """Traverse *tree* starting from its active node and evaluate."""
+    if tree is None:
+        raise ValueError("Scene node tree is None")
+
+    root = getattr(tree.nodes, "active", None)
+    if root is not None:
+        order = _topological_sort([root])
+    else:
+        order = _topological_sort(tree.nodes)
     for node in order:
         if getattr(node, "scene_nodes_dirty", True):
             _evaluate_node(node)

--- a/ui/operators.py
+++ b/ui/operators.py
@@ -8,5 +8,8 @@ class NODE_OT_sync_to_scene(bpy.types.Operator):
     def execute(self, context):
         from ..engine.evaluator import evaluate_scene_tree
         tree = context.scene.scene_node_tree
+        if tree is None:
+            self.report({'ERROR'}, "Scene has no Scene Node Tree")
+            return {'CANCELLED'}
         evaluate_scene_tree(tree)
         return {'FINISHED'}


### PR DESCRIPTION
## Summary
- handle `None` scene node trees in evaluator and operator
- evaluate the tree starting from the active node

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e1bc481fc833095788c3af2d78269