### PR TITLE
Add property sockets and update evaluation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,14 @@ from nodeitems_utils import register_node_categories, unregister_node_categories
 
 # NodeTree y sockets
 from .node_tree import SceneNodeTree
-from .nodes.base import SceneSocket
+from .nodes.base import (
+    SceneSocket,
+    FloatSocket,
+    IntSocket,
+    BoolSocket,
+    VectorSocket,
+    StringSocket,
+)
 
 # Nodos individuales
 from .nodes.scene_instance import SceneInstanceNode
@@ -35,6 +42,11 @@ from .engine import evaluate_scene_tree
 classes = [
     SceneNodeTree,
     SceneSocket,
+    FloatSocket,
+    IntSocket,
+    BoolSocket,
+    VectorSocket,
+    StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode,
     NODE_OT_sync_to_scene,

--- a/documentation.txt
+++ b/documentation.txt
@@ -70,6 +70,13 @@ Establece datos básicos de salida.
 - **File Path**: carpeta o archivo de destino.
 - **Format**: formato de imagen (OpenEXR o PNG).
 
+Conexión de propiedades
+-----------------------
+Los valores mostrados en los nodos también aparecen como sockets de entrada.
+Puedes conectar estos sockets entre distintos nodos para compartir el mismo
+valor. Si un socket está enlazado, el nodo tomará el valor de la conexión;
+de lo contrario utilizará el valor interno editable en el propio nodo.
+
 Flujo de trabajo recomendado
 ---------------------------
 1. Empieza con un nodo **Global Options** para configurar la escena.

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -34,17 +34,26 @@ def _topological_sort(nodes):
     return order
 
 
+def _socket_value(node, name, default=None):
+    sock = node.inputs.get(name)
+    if sock is None:
+        return default
+    if sock.is_linked and sock.links:
+        return getattr(sock.links[0].from_socket, "value", default)
+    return getattr(sock, "value", default)
+
+
 def _evaluate_scene_instance(node):
-    filepath = getattr(node, "file_path", "")
-    collection_path = getattr(node, "collection_path", "")
-    as_override = getattr(node, "as_override", False)
+    filepath = _socket_value(node, "File Path", getattr(node, "file_path", ""))
+    collection_path = _socket_value(node, "Collection Path", getattr(node, "collection_path", ""))
+    as_override = _socket_value(node, "As Override", getattr(node, "as_override", False))
     print(f"[scene_nodes] load instance {filepath}::{collection_path}, override={as_override}")
 
 
 def _evaluate_transform(node):
-    t = getattr(node, "translate", (0.0, 0.0, 0.0))
-    r = getattr(node, "rotate", (0.0, 0.0, 0.0))
-    s = getattr(node, "scale", (1.0, 1.0, 1.0))
+    t = _socket_value(node, "Translate", getattr(node, "translate", (0.0, 0.0, 0.0)))
+    r = _socket_value(node, "Rotate", getattr(node, "rotate", (0.0, 0.0, 0.0)))
+    s = _socket_value(node, "Scale", getattr(node, "scale", (1.0, 1.0, 1.0)))
     print(f"[scene_nodes] transform T={t} R={r} S={s}")
 
 
@@ -53,21 +62,21 @@ def _evaluate_group(_node):
 
 
 def _evaluate_light(node):
-    ltype = getattr(node, "light_type", "POINT")
-    energy = getattr(node, "energy", 1.0)
+    ltype = _socket_value(node, "Type", getattr(node, "light_type", "POINT"))
+    energy = _socket_value(node, "Energy", getattr(node, "energy", 1.0))
     print(f"[scene_nodes] create light {ltype} energy={energy}")
 
 
 def _evaluate_global_options(node):
-    res_x = getattr(node, "res_x", 1920)
-    res_y = getattr(node, "res_y", 1080)
-    samples = getattr(node, "samples", 128)
+    res_x = _socket_value(node, "Resolution X", getattr(node, "res_x", 1920))
+    res_y = _socket_value(node, "Resolution Y", getattr(node, "res_y", 1080))
+    samples = _socket_value(node, "Samples", getattr(node, "samples", 128))
     print(f"[scene_nodes] global options {res_x}x{res_y} samples={samples}")
 
 
 def _evaluate_outputs_stub(node):
-    path = getattr(node, "filepath", "")
-    fmt = getattr(node, "file_format", "OPEN_EXR")
+    path = _socket_value(node, "File Path", getattr(node, "filepath", ""))
+    fmt = _socket_value(node, "Format", getattr(node, "file_format", "OPEN_EXR"))
     print(f"[scene_nodes] outputs {path} format={fmt}")
 
 

--- a/nodes/base.py
+++ b/nodes/base.py
@@ -11,6 +11,71 @@ class SceneSocket(NodeSocket):
     def draw_color(self, context, node):
         return (0.8, 0.8, 0.2, 1.0)
 
+
+class FloatSocket(NodeSocket):
+    bl_idname = "FloatSocketType"
+    bl_label = "Float"
+
+    value: bpy.props.FloatProperty()
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, "value", text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.7, 1.0)
+
+
+class IntSocket(NodeSocket):
+    bl_idname = "IntSocketType"
+    bl_label = "Int"
+
+    value: bpy.props.IntProperty()
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, "value", text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.7, 1.0)
+
+
+class BoolSocket(NodeSocket):
+    bl_idname = "BoolSocketType"
+    bl_label = "Bool"
+
+    value: bpy.props.BoolProperty()
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, "value", text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.7, 1.0)
+
+
+class VectorSocket(NodeSocket):
+    bl_idname = "VectorSocketType"
+    bl_label = "Vector"
+
+    value: bpy.props.FloatVectorProperty(size=3)
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, "value", text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.7, 1.0)
+
+
+class StringSocket(NodeSocket):
+    bl_idname = "StringSocketType"
+    bl_label = "String"
+
+    value: bpy.props.StringProperty()
+
+    def draw(self, context, layout, node, text):
+        layout.prop(self, "value", text=text)
+
+    def draw_color(self, context, node):
+        return (0.7, 0.7, 0.7, 1.0)
+
 class BaseNode(Node):
     bl_label = "Base Scene Node"
     bl_width_default = 200

--- a/nodes/global_options.py
+++ b/nodes/global_options.py
@@ -1,5 +1,10 @@
 import bpy
-from .base import BaseNode, SceneSocket
+from .base import (
+    BaseNode,
+    SceneSocket,
+    IntSocket,
+    StringSocket,
+)
 
 class GlobalOptionsNode(BaseNode):
     bl_idname = "GlobalOptionsNodeType"
@@ -12,4 +17,18 @@ class GlobalOptionsNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
+        rx = self.inputs.new('IntSocketType', "Resolution X")
+        rx.value = self.res_x
+        ry = self.inputs.new('IntSocketType', "Resolution Y")
+        ry.value = self.res_y
+        sp = self.inputs.new('IntSocketType', "Samples")
+        sp.value = self.samples
+        cp = self.inputs.new('StringSocketType', "Camera Path")
+        cp.value = self.camera_path
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self.inputs["Resolution X"], "value")
+        layout.prop(self.inputs["Resolution Y"], "value")
+        layout.prop(self.inputs["Samples"], "value")
+        layout.prop(self.inputs["Camera Path"], "value")

--- a/nodes/group.py
+++ b/nodes/group.py
@@ -9,3 +9,6 @@ class GroupNode(BaseNode):
         self.inputs.new('SceneSocketType', "Scene 1")
         self.inputs.new('SceneSocketType', "Scene 2")
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, _context, _layout):
+        pass

--- a/nodes/light.py
+++ b/nodes/light.py
@@ -1,5 +1,11 @@
 import bpy
-from .base import BaseNode, SceneSocket
+from .base import (
+    BaseNode,
+    SceneSocket,
+    FloatSocket,
+    StringSocket,
+    VectorSocket,
+)
 
 class LightNode(BaseNode):
     bl_idname = "LightNodeType"
@@ -13,4 +19,15 @@ class LightNode(BaseNode):
     color: bpy.props.FloatVectorProperty(name="Color", subtype='COLOR', default=(1,1,1))
 
     def init(self, context):
+        t = self.inputs.new('StringSocketType', "Type")
+        t.value = self.light_type
+        e = self.inputs.new('FloatSocketType', "Energy")
+        e.value = self.energy
+        c = self.inputs.new('VectorSocketType', "Color")
+        c.value = self.color
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self.inputs["Type"], "value")
+        layout.prop(self.inputs["Energy"], "value")
+        layout.prop(self.inputs["Color"], "value")

--- a/nodes/outputs_stub.py
+++ b/nodes/outputs_stub.py
@@ -1,5 +1,9 @@
 import bpy
-from .base import BaseNode, SceneSocket
+from .base import (
+    BaseNode,
+    SceneSocket,
+    StringSocket,
+)
 
 class OutputsStubNode(BaseNode):
     bl_idname = "OutputsStubNodeType"
@@ -13,4 +17,12 @@ class OutputsStubNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
+        fp = self.inputs.new('StringSocketType', "File Path")
+        fp.value = self.filepath
+        fmt = self.inputs.new('StringSocketType', "Format")
+        fmt.value = self.file_format
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self.inputs["File Path"], "value")
+        layout.prop(self.inputs["Format"], "value")

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -1,5 +1,10 @@
 import bpy
-from .base import BaseNode, SceneSocket
+from .base import (
+    BaseNode,
+    SceneSocket,
+    StringSocket,
+    BoolSocket,
+)
 
 class SceneInstanceNode(BaseNode):
     bl_idname = "SceneInstanceNodeType"
@@ -10,4 +15,15 @@ class SceneInstanceNode(BaseNode):
     as_override: bpy.props.BoolProperty(name="As Override", default=False)
 
     def init(self, context):
+        fp = self.inputs.new('StringSocketType', "File Path")
+        fp.value = self.file_path
+        cp = self.inputs.new('StringSocketType', "Collection Path")
+        cp.value = self.collection_path
+        ov = self.inputs.new('BoolSocketType', "As Override")
+        ov.value = self.as_override
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self.inputs["File Path"], "value")
+        layout.prop(self.inputs["Collection Path"], "value")
+        layout.prop(self.inputs["As Override"], "value")

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -1,5 +1,9 @@
 import bpy
-from .base import BaseNode, SceneSocket
+from .base import (
+    BaseNode,
+    SceneSocket,
+    VectorSocket,
+)
 
 class TransformNode(BaseNode):
     bl_idname = "TransformNodeType"
@@ -11,4 +15,15 @@ class TransformNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
+        t = self.inputs.new('VectorSocketType', "Translate")
+        t.value = self.translate
+        r = self.inputs.new('VectorSocketType', "Rotate")
+        r.value = self.rotate
+        s = self.inputs.new('VectorSocketType', "Scale")
+        s.value = self.scale
         self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self.inputs["Translate"], "value")
+        layout.prop(self.inputs["Rotate"], "value")
+        layout.prop(self.inputs["Scale"], "value")


### PR DESCRIPTION
## Summary
- add generic value sockets in base module
- expose node properties as input sockets and draw them on each node
- resolve property values through sockets during evaluation
- document how property sockets can be linked

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e7c3365288330b6130310a203bd41