### PR TITLE
Fix duplicated socket inputs

### DIFF
--- a/nodes/global_options.py
+++ b/nodes/global_options.py
@@ -28,7 +28,4 @@ class GlobalOptionsNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        layout.prop(self.inputs["Resolution X"], "value")
-        layout.prop(self.inputs["Resolution Y"], "value")
-        layout.prop(self.inputs["Samples"], "value")
-        layout.prop(self.inputs["Camera Path"], "value")
+        pass  # Inputs already expose editable values next to their sockets

--- a/nodes/light.py
+++ b/nodes/light.py
@@ -28,6 +28,4 @@ class LightNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        layout.prop(self.inputs["Type"], "value")
-        layout.prop(self.inputs["Energy"], "value")
-        layout.prop(self.inputs["Color"], "value")
+        pass  # Inputs already expose editable values next to their sockets

--- a/nodes/outputs_stub.py
+++ b/nodes/outputs_stub.py
@@ -24,5 +24,4 @@ class OutputsStubNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        layout.prop(self.inputs["File Path"], "value")
-        layout.prop(self.inputs["Format"], "value")
+        pass  # Inputs already expose editable values next to their sockets

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -24,6 +24,4 @@ class SceneInstanceNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        layout.prop(self.inputs["File Path"], "value")
-        layout.prop(self.inputs["Collection Path"], "value")
-        layout.prop(self.inputs["As Override"], "value")
+        pass  # Inputs already expose editable values next to their sockets

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -24,6 +24,4 @@ class TransformNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        layout.prop(self.inputs["Translate"], "value")
-        layout.prop(self.inputs["Rotate"], "value")
-        layout.prop(self.inputs["Scale"], "value")
+        pass  # Inputs already expose editable values next to their sockets


### PR DESCRIPTION
## Summary
- remove redundant UI props from node buttons

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e8089d9548330ad0201b072a7810c