### PR TITLE
Fix missing node editor menu

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,7 @@ from .nodes.outputs_stub import OutputsStubNode
 from .ui.node_categories import node_categories
 from .ui.node_editor import SCENE_GRAPH_MT_add
 from .ui.operators import NODE_OT_sync_to_scene
+from . import ui
 
 # Engine
 from .engine import evaluate_scene_tree
@@ -60,9 +61,11 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.scene_node_tree = bpy.props.PointerProperty(type=SceneNodeTree)
     register_node_categories(NODETREE_CATEGORY, node_categories)
+    ui.register()
 
 
 def unregister():
+    ui.unregister()
     unregister_node_categories(NODETREE_CATEGORY)
     del bpy.types.Scene.scene_node_tree
     for cls in reversed(classes):

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -6,3 +6,13 @@ __all__ = [
     "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
 ]
+from . import node_editor
+
+
+def register():
+    node_editor.register()
+
+
+def unregister():
+    node_editor.unregister()
+

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -12,3 +12,16 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"
         layout.operator("node.add_node", text="Render Outputs").type = "OutputsStubNodeType"
+
+def menu_draw(self, context):
+    if context.space_data.tree_type == 'SceneNodeTreeType':
+        self.layout.menu(SCENE_GRAPH_MT_add.bl_idname)
+
+
+def register():
+    bpy.types.NODE_MT_add.append(menu_draw)
+
+
+def unregister():
+    bpy.types.NODE_MT_add.remove(menu_draw)
+


### PR DESCRIPTION
## Summary
- register `SCENE_GRAPH_MT_add` menu properly
- expose UI register/unregister helpers

## Testing
- `python -m py_compile __init__.py engine/__init__.py engine/evaluator.py nodes/*.py ui/*.py node_tree.py`

------
https://chatgpt.com/codex/tasks/task_e_684e83681c5883309340344750929f5c