### PR TITLE
Add unified Input node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ from .nodes.group import GroupNode
 from .nodes.light import LightNode
 from .nodes.global_options import GlobalOptionsNode
 from .nodes.outputs_stub import OutputsStubNode
+from .nodes.input import InputNode
 
 # UI
 from .ui.node_categories import node_categories
@@ -49,6 +50,7 @@ classes = [
     StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode,
+    InputNode,
     NODE_OT_sync_to_scene,
     SCENE_GRAPH_MT_add,
 ]

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -80,6 +80,11 @@ def _evaluate_outputs_stub(node):
     print(f"[scene_nodes] outputs {path} format={fmt}")
 
 
+def _evaluate_input(node):
+    val = _socket_value(node, "Value", None)
+    print(f"[scene_nodes] input value={val}")
+
+
 def _evaluate_node(node):
     ntype = node.bl_idname
     if ntype == "SceneInstanceNodeType":
@@ -94,6 +99,8 @@ def _evaluate_node(node):
         _evaluate_global_options(node)
     elif ntype == "OutputsStubNodeType":
         _evaluate_outputs_stub(node)
+    elif ntype == "InputNodeType":
+        _evaluate_input(node)
     else:
         print(f"[scene_nodes] unknown node type {ntype}")
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -4,8 +4,10 @@ from .group import GroupNode
 from .light import LightNode
 from .global_options import GlobalOptionsNode
 from .outputs_stub import OutputsStubNode
+from .input import InputNode
 
 __all__ = [
     "SceneInstanceNode", "TransformNode", "GroupNode",
-    "LightNode", "GlobalOptionsNode", "OutputsStubNode"
+    "LightNode", "GlobalOptionsNode", "OutputsStubNode",
+    "InputNode",
 ]

--- a/nodes/input.py
+++ b/nodes/input.py
@@ -1,0 +1,76 @@
+import bpy
+from .base import (
+    BaseNode,
+    FloatSocket,
+    IntSocket,
+    BoolSocket,
+    VectorSocket,
+    StringSocket,
+)
+
+
+class InputNode(BaseNode):
+    bl_idname = "InputNodeType"
+    bl_label = "Input"
+
+    input_type: bpy.props.EnumProperty(
+        items=[
+            ('FLOAT', 'Float', ''),
+            ('INT', 'Int', ''),
+            ('VECTOR', 'Vector', ''),
+            ('STRING', 'String', ''),
+            ('BOOL', 'Bool', ''),
+        ],
+        name="Type",
+        default='FLOAT',
+        update=lambda self, context: self._update_socket()
+    )
+
+    float_value: bpy.props.FloatProperty(name="Float Value", default=0.0)
+    int_value: bpy.props.IntProperty(name="Int Value", default=0)
+    bool_value: bpy.props.BoolProperty(name="Bool Value", default=False)
+    vector_value: bpy.props.FloatVectorProperty(name="Vector Value", size=3)
+    string_value: bpy.props.StringProperty(name="String Value")
+
+    def _socket_type(self):
+        mapping = {
+            'FLOAT': 'FloatSocketType',
+            'INT': 'IntSocketType',
+            'VECTOR': 'VectorSocketType',
+            'STRING': 'StringSocketType',
+            'BOOL': 'BoolSocketType',
+        }
+        return mapping.get(self.input_type, 'FloatSocketType')
+
+    def _socket_value(self):
+        return {
+            'FLOAT': self.float_value,
+            'INT': self.int_value,
+            'VECTOR': self.vector_value,
+            'STRING': self.string_value,
+            'BOOL': self.bool_value,
+        }.get(self.input_type, None)
+
+    def _update_socket(self):
+        if self.outputs:
+            self.outputs.remove(self.outputs[0])
+        sock = self.outputs.new(self._socket_type(), "Value")
+        value = self._socket_value()
+        if value is not None:
+            sock.value = value
+
+    def init(self, context):
+        self.outputs.new(self._socket_type(), "Value")
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "input_type")
+        if self.input_type == 'FLOAT':
+            layout.prop(self, "float_value", text="Value")
+        elif self.input_type == 'INT':
+            layout.prop(self, "int_value", text="Value")
+        elif self.input_type == 'VECTOR':
+            layout.prop(self, "vector_value", text="Value")
+        elif self.input_type == 'STRING':
+            layout.prop(self, "string_value", text="Value")
+        elif self.input_type == 'BOOL':
+            layout.prop(self, "bool_value", text="Value")

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -14,5 +14,6 @@ node_categories = [
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),
         NodeItem("OutputsStubNodeType"),
+        NodeItem("InputNodeType"),
     ])
 ]

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.types import Menu
 
+
 class SCENE_GRAPH_MT_add(Menu):
     bl_label = "Add Scene Node"
 
@@ -12,3 +13,5 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"
         layout.operator("node.add_node", text="Render Outputs").type = "OutputsStubNodeType"
+        layout.operator("node.add_node", text="Input").type = "InputNodeType"
+


### PR DESCRIPTION
## Summary
- add new `InputNode` that can output different data types
- register and expose the new node in menus and categories
- support input nodes in evaluator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e81169b808330ba931cf706b7b940