### PR TITLE
Implement basic scene evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ out = tree.nodes.new("OutputsStubNodeType")
 # Link instance to output
 tree.links.new(inst.outputs[0], out.inputs[0])
 
-# Evaluate the tree (prints to the console)
+# Evaluate the tree (applies changes to the scene)
 evaluate_scene_tree(tree)
 ```

--- a/documentation.txt
+++ b/documentation.txt
@@ -86,8 +86,9 @@ Flujo de trabajo recomendado
 5. Finaliza con **Render Outputs** para definir la salida.
 6. Ejecuta **Sync to Scene** para aplicar los cambios.
 
-Ten en cuenta que este complemento es experimental y la evaluación actualmente
-solo imprime información en la consola de Blender. Sirve como base para futuros
-flujos de trabajo nodales de ensamblaje de escenas.
+Ten en cuenta que este complemento sigue siendo experimental, pero ahora la
+evaluación del árbol aplica los cambios directamente en la escena de Blender en
+lugar de limitarse a imprimir información en la consola. Sirve como base para
+futuros flujos de trabajo nodales de ensamblaje de escenas.
 
 ---


### PR DESCRIPTION
## Summary
- implement light, transform, scene instance, group, global options and outputs evaluation
- wire inputs between nodes and store evaluated collections
- update docs to mention scene updates instead of console prints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e9151bcc08330979e76744a67ac8b