### PR TITLE
Fix library override creation

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -74,7 +74,10 @@ def _evaluate_scene_instance(node, _inputs):
 
     bpy.context.scene.collection.children.link(collection)
     if as_override:
-        collection = collection.override_create(bpy.context.scene.collection)
+        collection = collection.override_create(
+            bpy.context.scene.collection,
+            remap_local_usages=True,
+        )
 
     node.scene_nodes_output = collection
     return collection


### PR DESCRIPTION
## Summary
- fix `Collection.override_create` call for latest Blender API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e94871fa48330982d656cec52b5ee