### PR TITLE
Make node tree global

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 3. Connect them with the provided `Scene` sockets.
 
 The tree can be evaluated via the **Sync to Scene** operator (accessible with **F3**) or from a Python script.
+The operator uses the Scene Graph tree currently open in the Node Editor (or the
+first one it finds in the file) so scenes don't need their own tree pointer.
 
 ## Quick Example
 

--- a/__init__.py
+++ b/__init__.py
@@ -59,7 +59,6 @@ NODETREE_CATEGORY = 'SCENE_NODES'
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-    bpy.types.Scene.scene_node_tree = bpy.props.PointerProperty(type=SceneNodeTree)
     register_node_categories(NODETREE_CATEGORY, node_categories)
     ui.register()
 
@@ -67,6 +66,5 @@ def register():
 def unregister():
     ui.unregister()
     unregister_node_categories(NODETREE_CATEGORY)
-    del bpy.types.Scene.scene_node_tree
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/documentation.txt
+++ b/documentation.txt
@@ -26,6 +26,9 @@ Uso básico
 3. Conecta las salidas y entradas de tipo `Scene` entre nodos.
 4. Ejecuta el operador **Sync to Scene** (menú F3) para evaluar el árbol y
    sincronizarlo con la escena de Blender.
+   El operador utiliza el árbol de Scene Graph activo en el Node Editor (o el
+   primero que encuentre en el archivo), por lo que las escenas no necesitan
+   tener un árbol asignado.
 
 También es posible evaluar el arbol mediante Python con:
 

--- a/ui/operators.py
+++ b/ui/operators.py
@@ -7,9 +7,23 @@ class NODE_OT_sync_to_scene(bpy.types.Operator):
 
     def execute(self, context):
         from ..engine.evaluator import evaluate_scene_tree
-        tree = context.scene.scene_node_tree
+
+        tree = None
+
+        if context.area and context.area.type == 'NODE_EDITOR':
+            space = context.space_data
+            if space and space.tree_type == 'SceneNodeTreeType':
+                tree = space.node_tree
+
         if tree is None:
-            self.report({'ERROR'}, "Scene has no Scene Node Tree")
+            for nt in bpy.data.node_groups:
+                if nt.bl_idname == 'SceneNodeTreeType':
+                    tree = nt
+                    break
+
+        if tree is None:
+            self.report({'ERROR'}, "No Scene Node Tree found")
             return {'CANCELLED'}
+
         evaluate_scene_tree(tree)
         return {'FINISHED'}


### PR DESCRIPTION
## Summary
- drop Scene.scene_node_tree property to avoid scene requirement
- evaluate active Scene Graph tree in operator
- update docs to reflect global tree usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e99b96be4833090df159fc1075db3