### PR TITLE
Fix override_create call

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -91,10 +91,7 @@ def _evaluate_scene_instance(node, _inputs, scene):
 
     scene.collection.children.link(collection)
     if as_override:
-        collection = collection.override_create(
-            scene.collection,
-            remap_local_usages=True,
-        )
+        collection = collection.override_create(scene.collection)
 
     node.scene_nodes_output = collection
     return collection


### PR DESCRIPTION
## Summary
- fix Collection override call to use Blender 4.0 API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e9b91bc0c8330921672609e99e758