### PR TITLE
Add generic Input node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ from .nodes.group import GroupNode
 from .nodes.light import LightNode
 from .nodes.global_options import GlobalOptionsNode
 from .nodes.outputs_stub import OutputsStubNode
+from .nodes.input import InputNode
 
 # UI
 from .ui.node_categories import node_categories
@@ -49,7 +50,7 @@ classes = [
     VectorSocket,
     StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
-    LightNode, GlobalOptionsNode, OutputsStubNode,
+    LightNode, GlobalOptionsNode, OutputsStubNode, InputNode,
     NODE_OT_sync_to_scene,
     SCENE_GRAPH_MT_add,
 ]

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -200,6 +200,11 @@ def _evaluate_outputs_stub(node, _inputs, scene):
     return node.scene_nodes_output
 
 
+def _evaluate_input(node, _inputs, _scene):
+    node.scene_nodes_output = None
+    return None
+
+
 def _evaluate_node(node, scene):
     inputs = _collect_input_scenes(node)
     ntype = node.bl_idname
@@ -215,6 +220,8 @@ def _evaluate_node(node, scene):
         return _evaluate_global_options(node, inputs, scene)
     elif ntype == "OutputsStubNodeType":
         return _evaluate_outputs_stub(node, inputs, scene)
+    elif ntype == "InputNodeType":
+        return _evaluate_input(node, inputs, scene)
     else:
         print(f"[scene_nodes] unknown node type {ntype}")
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -4,8 +4,10 @@ from .group import GroupNode
 from .light import LightNode
 from .global_options import GlobalOptionsNode
 from .outputs_stub import OutputsStubNode
+from .input import InputNode
 
 __all__ = [
     "SceneInstanceNode", "TransformNode", "GroupNode",
-    "LightNode", "GlobalOptionsNode", "OutputsStubNode"
+    "LightNode", "GlobalOptionsNode", "OutputsStubNode",
+    "InputNode",
 ]

--- a/nodes/input.py
+++ b/nodes/input.py
@@ -1,0 +1,78 @@
+import bpy
+from .base import (
+    BaseNode,
+    FloatSocket,
+    IntSocket,
+    BoolSocket,
+    VectorSocket,
+    StringSocket,
+)
+
+
+class InputNode(BaseNode):
+    bl_idname = "InputNodeType"
+    bl_label = "Input"
+
+    data_type: bpy.props.EnumProperty(
+        name="Type",
+        items=[
+            ('FLOAT', "Float", ""),
+            ('INT', "Int", ""),
+            ('BOOL', "Bool", ""),
+            ('VECTOR', "Vector", ""),
+            ('STRING', "String", ""),
+        ],
+        default='FLOAT',
+        update=lambda self, context: self.update_socket(),
+    )
+
+    float_val: bpy.props.FloatProperty(update=lambda self, ctx: self.update_socket_value())
+    int_val: bpy.props.IntProperty(update=lambda self, ctx: self.update_socket_value())
+    bool_val: bpy.props.BoolProperty(update=lambda self, ctx: self.update_socket_value())
+    vector_val: bpy.props.FloatVectorProperty(size=3, update=lambda self, ctx: self.update_socket_value())
+    string_val: bpy.props.StringProperty(update=lambda self, ctx: self.update_socket_value())
+
+    def init(self, context):
+        self.update_socket()
+
+    def update_socket(self):
+        while self.outputs:
+            self.outputs.remove(self.outputs[0])
+        type_map = {
+            'FLOAT': 'FloatSocketType',
+            'INT': 'IntSocketType',
+            'BOOL': 'BoolSocketType',
+            'VECTOR': 'VectorSocketType',
+            'STRING': 'StringSocketType',
+        }
+        stype = type_map.get(self.data_type, 'FloatSocketType')
+        self.outputs.new(stype, "Value")
+        self.update_socket_value()
+
+    def update_socket_value(self):
+        if not self.outputs:
+            return
+        sock = self.outputs[0]
+        if self.data_type == 'FLOAT':
+            sock.value = self.float_val
+        elif self.data_type == 'INT':
+            sock.value = self.int_val
+        elif self.data_type == 'BOOL':
+            sock.value = self.bool_val
+        elif self.data_type == 'VECTOR':
+            sock.value = self.vector_val
+        elif self.data_type == 'STRING':
+            sock.value = self.string_val
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "data_type")
+        if self.data_type == 'FLOAT':
+            layout.prop(self, "float_val", text="Value")
+        elif self.data_type == 'INT':
+            layout.prop(self, "int_val", text="Value")
+        elif self.data_type == 'BOOL':
+            layout.prop(self, "bool_val", text="Value")
+        elif self.data_type == 'VECTOR':
+            layout.prop(self, "vector_val", text="Value")
+        elif self.data_type == 'STRING':
+            layout.prop(self, "string_val", text="Value")

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -10,6 +10,7 @@ node_categories = [
     SceneNodeCategory('SCENE_NODES', "Scene Nodes", items=[
         NodeItem("SceneInstanceNodeType"),
         NodeItem("TransformNodeType"),
+        NodeItem("InputNodeType"),
         NodeItem("GroupNodeType"),
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -8,6 +8,7 @@ class SCENE_GRAPH_MT_add(Menu):
         layout = self.layout
         layout.operator("node.add_node", text="Scene Instance").type = "SceneInstanceNodeType"
         layout.operator("node.add_node", text="Transform").type = "TransformNodeType"
+        layout.operator("node.add_node", text="Input").type = "InputNodeType"
         layout.operator("node.add_node", text="Group").type = "GroupNodeType"
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"


### PR DESCRIPTION
## Summary
- introduce Input node with enum-selectable data types
- integrate node in add-on registration
- expose Input in node categories and Add menu
- handle Input node in evaluator

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ea0ba08848330a3d0c0539ead2526