### PR TITLE
Add generic property socket helper

### DIFF
--- a/nodes/global_options.py
+++ b/nodes/global_options.py
@@ -1,31 +1,25 @@
 import bpy
-from .base import (
-    BaseNode,
-    SceneSocket,
-    IntSocket,
-    StringSocket,
-)
+from .base import BaseNode, build_props_and_sockets
 
 class GlobalOptionsNode(BaseNode):
     bl_idname = "GlobalOptionsNodeType"
     bl_label = "Global Options"
 
-    res_x: bpy.props.IntProperty(name="Resolution X", default=1920)
-    res_y: bpy.props.IntProperty(name="Resolution Y", default=1080)
-    samples: bpy.props.IntProperty(name="Samples", default=128)
-    camera_path: bpy.props.StringProperty(name="Camera Path")
-
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        rx = self.inputs.new('IntSocketType', "Resolution X")
-        rx.value = self.res_x
-        ry = self.inputs.new('IntSocketType', "Resolution Y")
-        ry.value = self.res_y
-        sp = self.inputs.new('IntSocketType', "Samples")
-        sp.value = self.samples
-        cp = self.inputs.new('StringSocketType', "Camera Path")
-        cp.value = self.camera_path
+        self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    GlobalOptionsNode,
+    [
+        ("res_x", "int", {"name": "Resolution X", "default": 1920}),
+        ("res_y", "int", {"name": "Resolution Y", "default": 1080}),
+        ("samples", "int", {"name": "Samples", "default": 128}),
+        ("camera_path", "string", {"name": "Camera Path"}),
+    ],
+)

--- a/nodes/light.py
+++ b/nodes/light.py
@@ -1,31 +1,39 @@
 import bpy
-from .base import (
-    BaseNode,
-    SceneSocket,
-    FloatSocket,
-    StringSocket,
-    VectorSocket,
-)
+from .base import BaseNode, build_props_and_sockets
 
 class LightNode(BaseNode):
     bl_idname = "LightNodeType"
     bl_label = "Light"
 
-    light_type: bpy.props.EnumProperty(
-        items=[('POINT','Point',''),('SUN','Sun',''),('SPOT','Spot',''),('AREA','Area','')],
-        name="Type"
-    )
-    energy: bpy.props.FloatProperty(name="Energy", default=10.0)
-    color: bpy.props.FloatVectorProperty(name="Color", subtype='COLOR', default=(1,1,1))
-
     def init(self, context):
-        t = self.inputs.new('StringSocketType', "Type")
-        t.value = self.light_type
-        e = self.inputs.new('FloatSocketType', "Energy")
-        e.value = self.energy
-        c = self.inputs.new('VectorSocketType', "Color")
-        c.value = self.color
+        self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    LightNode,
+    [
+        (
+            "light_type",
+            "enum",
+            {
+                "items": [
+                    ("POINT", "Point", ""),
+                    ("SUN", "Sun", ""),
+                    ("SPOT", "Spot", ""),
+                    ("AREA", "Area", ""),
+                ],
+                "name": "Type",
+            },
+        ),
+        ("energy", "float", {"name": "Energy", "default": 10.0}),
+        (
+            "color",
+            "vector",
+            {"name": "Color", "subtype": "COLOR", "default": (1, 1, 1)},
+        ),
+    ],
+)

--- a/nodes/outputs_stub.py
+++ b/nodes/outputs_stub.py
@@ -1,27 +1,37 @@
 import bpy
-from .base import (
-    BaseNode,
-    SceneSocket,
-    StringSocket,
-)
+from .base import BaseNode, build_props_and_sockets
 
 class OutputsStubNode(BaseNode):
     bl_idname = "OutputsStubNodeType"
     bl_label = "Render Outputs"
 
-    filepath: bpy.props.StringProperty(name="File Path", subtype='FILE_PATH')
-    file_format: bpy.props.EnumProperty(
-        items=[('OPEN_EXR','OpenEXR',''),('PNG','PNG','')],
-        name="Format"
-    )
-
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        fp = self.inputs.new('StringSocketType', "File Path")
-        fp.value = self.filepath
-        fmt = self.inputs.new('StringSocketType', "Format")
-        fmt.value = self.file_format
+        self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    OutputsStubNode,
+    [
+        (
+            "filepath",
+            "string",
+            {"name": "File Path", "subtype": "FILE_PATH"},
+        ),
+        (
+            "file_format",
+            "enum",
+            {
+                "items": [
+                    ("OPEN_EXR", "OpenEXR", ""),
+                    ("PNG", "PNG", ""),
+                ],
+                "name": "Format",
+            },
+        ),
+    ],
+)

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -1,35 +1,48 @@
 import bpy
-from .base import (
-    BaseNode,
-    SceneSocket,
-    StringSocket,
-)
+from .base import BaseNode, build_props_and_sockets
 
 class SceneInstanceNode(BaseNode):
     bl_idname = "SceneInstanceNodeType"
     bl_label = "Scene Instance"
 
-    file_path: bpy.props.StringProperty(name="File Path", subtype='FILE_PATH')
-    collection_path: bpy.props.StringProperty(name="Collection Path")
-    load_mode: bpy.props.EnumProperty(
-        name="Load Mode",
-        items=[
-            ('APPEND', "Append", "Append the collection"),
-            ('INSTANCE', "Instance", "Append collection and create instance object"),
-            ('LINK', "Link", "Link the collection"),
-            ('OVERRIDE', "Link Override", "Link the collection and create a library override"),
-        ],
-        default='APPEND'
-    )
-
     def init(self, context):
-        fp = self.inputs.new('StringSocketType', "File Path")
-        fp.value = self.file_path
-        cp = self.inputs.new('StringSocketType', "Collection Path")
-        cp.value = self.collection_path
-        lm = self.inputs.new('StringSocketType', "Load Mode")
-        lm.value = self.load_mode
+        self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    SceneInstanceNode,
+    [
+        (
+            "file_path",
+            "string",
+            {"name": "File Path", "subtype": "FILE_PATH"},
+        ),
+        (
+            "collection_path",
+            "string",
+            {"name": "Collection Path"},
+        ),
+        (
+            "load_mode",
+            "enum",
+            {
+                "name": "Load Mode",
+                "items": [
+                    ("APPEND", "Append", "Append the collection"),
+                    ("INSTANCE", "Instance", "Append collection and create instance object"),
+                    ("LINK", "Link", "Link the collection"),
+                    (
+                        "OVERRIDE",
+                        "Link Override",
+                        "Link the collection and create a library override",
+                    ),
+                ],
+                "default": "APPEND",
+            },
+        ),
+    ],
+)

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -1,27 +1,24 @@
 import bpy
-from .base import (
-    BaseNode,
-    SceneSocket,
-    VectorSocket,
-)
+from .base import BaseNode, build_props_and_sockets
 
 class TransformNode(BaseNode):
     bl_idname = "TransformNodeType"
     bl_label = "Transform"
 
-    translate: bpy.props.FloatVectorProperty(name="Translate", size=3)
-    rotate: bpy.props.FloatVectorProperty(name="Rotate", size=3)
-    scale: bpy.props.FloatVectorProperty(name="Scale", size=3, default=(1, 1, 1))
-
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        t = self.inputs.new('VectorSocketType', "Translate")
-        t.value = self.translate
-        r = self.inputs.new('VectorSocketType', "Rotate")
-        r.value = self.rotate
-        s = self.inputs.new('VectorSocketType', "Scale")
-        s.value = self.scale
+        self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    TransformNode,
+    [
+        ("translate", "vector", {"name": "Translate", "size": 3}),
+        ("rotate", "vector", {"name": "Rotate", "size": 3}),
+        ("scale", "vector", {"name": "Scale", "size": 3, "default": (1, 1, 1)}),
+    ],
+)


### PR DESCRIPTION
## Summary
- add `build_props_and_sockets` helper in `nodes/base.py`
- refactor scene node classes to use the helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ea45d7bf483309428e41cc8c09350