### PR TITLE
Add render and output property nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ tree = bpy.data.node_groups.new("Example", "SceneNodeTreeType")
 
 # Add nodes
 inst = tree.nodes.new("SceneInstanceNodeType")
-out = tree.nodes.new("OutputsStubNodeType")
+out = tree.nodes.new("OutputPropertiesNodeType")
 
 # Link instance to output
 tree.links.new(inst.outputs[0], out.inputs[0])

--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,9 @@ from .nodes.group import GroupNode
 from .nodes.light import LightNode
 from .nodes.global_options import GlobalOptionsNode
 from .nodes.outputs_stub import OutputsStubNode
+from .nodes.cycles_render import CyclesRenderNode
+from .nodes.eevee_render import EeveeRenderNode
+from .nodes.output_properties import OutputPropertiesNode
 from .nodes.scene_output import SceneOutputNode
 from .nodes.input import InputNode
 
@@ -51,7 +54,9 @@ classes = [
     VectorSocket,
     StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
-    LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
+    LightNode, GlobalOptionsNode, OutputsStubNode,
+    CyclesRenderNode, EeveeRenderNode, OutputPropertiesNode,
+    SceneOutputNode, InputNode,
     NODE_OT_sync_to_scene,
     SCENE_GRAPH_MT_add,
 ]

--- a/documentation.txt
+++ b/documentation.txt
@@ -70,10 +70,26 @@ Define parámetros globales de la escena.
 - **Samples**: número de muestras para el render.
 - **Camera Path**: ruta a una cámara existente en el archivo.
 
+### Cycles Render Properties
+Ajustes específicos del motor Cycles.
+- **Samples**: número de muestras.
+- **Use Denoise**: aplica denoising.
+
+### EEVEE Render Properties
+Ajustes específicos para EEVEE.
+- **Samples**: número de muestras.
+- **Bloom**: activa el efecto de bloom.
+
 ### Render Outputs
 Establece datos básicos de salida.
 - **File Path**: carpeta o archivo de destino.
 - **Format**: formato de imagen (OpenEXR o PNG).
+
+### Output Properties
+Define la configuración final de salida.
+- **File Path**: carpeta o archivo de destino.
+- **Format**: formato de imagen.
+- **Resolution X/Y**: resolución del render.
 
 ### Scene Output
 Define el nombre de la escena resultante. Debe situarse al final del 
@@ -92,9 +108,10 @@ Flujo de trabajo recomendado
 2. Añade instancias o grupos según sea necesario.
 3. Inserta nodos **Transform** para posicionar los elementos.
 4. Utiliza **Light** para iluminar.
-5. Añade un nodo **Render Outputs** si necesitas configurar la salida.
-6. Cierra el árbol con **Scene Output** para crear la escena.
-7. Ejecuta **Sync to Scene** para aplicar los cambios.
+5. Configura las propiedades de render con los nodos **Cycles Render** o **EEVEE Render**.
+6. Añade un nodo **Output Properties** para definir la salida.
+7. Cierra el árbol con **Scene Output** para crear la escena.
+8. Ejecuta **Sync to Scene** para aplicar los cambios.
 
 Ten en cuenta que este complemento sigue siendo experimental, pero ahora la
 evaluación del árbol aplica los cambios directamente en la escena de Blender en

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -200,6 +200,45 @@ def _evaluate_outputs_stub(node, _inputs, scene):
     return node.scene_nodes_output
 
 
+def _evaluate_cycles_render(node, _inputs, scene):
+    samples = _socket_value(node, "Samples", getattr(node, "samples", 128))
+    use_denoise = _socket_value(node, "Use Denoise", getattr(node, "use_denoise", False))
+
+    if hasattr(scene, "cycles"):
+        scene.cycles.samples = samples
+        scene.cycles.use_denoising = use_denoise
+
+    node.scene_nodes_output = scene.collection
+    return node.scene_nodes_output
+
+
+def _evaluate_eevee_render(node, _inputs, scene):
+    samples = _socket_value(node, "Samples", getattr(node, "samples", 64))
+    use_bloom = _socket_value(node, "Bloom", getattr(node, "use_bloom", False))
+
+    if hasattr(scene, "eevee"):
+        scene.eevee.taa_render_samples = samples
+        scene.eevee.use_bloom = use_bloom
+
+    node.scene_nodes_output = scene.collection
+    return node.scene_nodes_output
+
+
+def _evaluate_output_properties(node, _inputs, scene):
+    path = _socket_value(node, "File Path", getattr(node, "filepath", ""))
+    fmt = _socket_value(node, "Format", getattr(node, "file_format", "OPEN_EXR"))
+    res_x = _socket_value(node, "Resolution X", getattr(node, "res_x", 1920))
+    res_y = _socket_value(node, "Resolution Y", getattr(node, "res_y", 1080))
+
+    scene.render.filepath = path
+    scene.render.image_settings.file_format = fmt
+    scene.render.resolution_x = res_x
+    scene.render.resolution_y = res_y
+
+    node.scene_nodes_output = scene.collection
+    return node.scene_nodes_output
+
+
 def _evaluate_input(node, _inputs, _scene):
     node.scene_nodes_output = None
     return None
@@ -225,6 +264,12 @@ def _evaluate_node(node, scene):
         return _evaluate_global_options(node, inputs, scene)
     elif ntype == "OutputsStubNodeType":
         return _evaluate_outputs_stub(node, inputs, scene)
+    elif ntype == "CyclesRenderNodeType":
+        return _evaluate_cycles_render(node, inputs, scene)
+    elif ntype == "EeveeRenderNodeType":
+        return _evaluate_eevee_render(node, inputs, scene)
+    elif ntype == "OutputPropertiesNodeType":
+        return _evaluate_output_properties(node, inputs, scene)
     elif ntype == "SceneOutputNodeType":
         return _evaluate_scene_output(node, inputs, scene)
     elif ntype == "InputNodeType":

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -4,11 +4,15 @@ from .group import GroupNode
 from .light import LightNode
 from .global_options import GlobalOptionsNode
 from .outputs_stub import OutputsStubNode
+from .cycles_render import CyclesRenderNode
+from .eevee_render import EeveeRenderNode
+from .output_properties import OutputPropertiesNode
 from .scene_output import SceneOutputNode
 from .input import InputNode
 
 __all__ = [
     "SceneInstanceNode", "TransformNode", "GroupNode",
     "LightNode", "GlobalOptionsNode", "OutputsStubNode",
+    "CyclesRenderNode", "EeveeRenderNode", "OutputPropertiesNode",
     "SceneOutputNode", "InputNode",
 ]

--- a/nodes/cycles_render.py
+++ b/nodes/cycles_render.py
@@ -1,0 +1,24 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class CyclesRenderNode(BaseNode):
+    bl_idname = "CyclesRenderNodeType"
+    bl_label = "Cycles Render Properties"
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_props_and_sockets(
+    CyclesRenderNode,
+    [
+        ("samples", "int", {"name": "Samples", "default": 128}),
+        ("use_denoise", "bool", {"name": "Use Denoise", "default": False}),
+    ],
+)

--- a/nodes/eevee_render.py
+++ b/nodes/eevee_render.py
@@ -1,0 +1,24 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class EeveeRenderNode(BaseNode):
+    bl_idname = "EeveeRenderNodeType"
+    bl_label = "Eevee Render Properties"
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_props_and_sockets(
+    EeveeRenderNode,
+    [
+        ("samples", "int", {"name": "Samples", "default": 64}),
+        ("use_bloom", "bool", {"name": "Bloom", "default": False}),
+    ],
+)

--- a/nodes/output_properties.py
+++ b/nodes/output_properties.py
@@ -1,0 +1,36 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class OutputPropertiesNode(BaseNode):
+    bl_idname = "OutputPropertiesNodeType"
+    bl_label = "Output Properties"
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_props_and_sockets(
+    OutputPropertiesNode,
+    [
+        ("filepath", "string", {"name": "File Path", "subtype": "FILE_PATH"}),
+        (
+            "file_format",
+            "enum",
+            {
+                "items": [
+                    ("OPEN_EXR", "OpenEXR", ""),
+                    ("PNG", "PNG", ""),
+                ],
+                "name": "Format",
+            },
+        ),
+        ("res_x", "int", {"name": "Resolution X", "default": 1920}),
+        ("res_y", "int", {"name": "Resolution Y", "default": 1080}),
+    ],
+)

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -15,6 +15,9 @@ node_categories = [
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),
         NodeItem("OutputsStubNodeType"),
+        NodeItem("CyclesRenderNodeType"),
+        NodeItem("EeveeRenderNodeType"),
+        NodeItem("OutputPropertiesNodeType"),
         NodeItem("SceneOutputNodeType"),
     ])
 ]

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -14,6 +14,9 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"
         layout.operator("node.add_node", text="Render Outputs").type = "OutputsStubNodeType"
+        layout.operator("node.add_node", text="Cycles Render").type = "CyclesRenderNodeType"
+        layout.operator("node.add_node", text="Eevee Render").type = "EeveeRenderNodeType"
+        layout.operator("node.add_node", text="Output Properties").type = "OutputPropertiesNodeType"
         layout.operator("node.add_node", text="Scene Output").type = "SceneOutputNodeType"
 
 def menu_draw(self, context):


### PR DESCRIPTION
## Summary
- add CyclesRenderNode, EeveeRenderNode and OutputPropertiesNode
- support new nodes in evaluator and registration
- document new nodes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ebb0543248330a5352e8121a61be5