### PR TITLE
Move node settings to N-panel with socket toggles

### DIFF
--- a/nodes/cycles_render.py
+++ b/nodes/cycles_render.py
@@ -12,22 +12,7 @@ class CyclesRenderNode(BaseNode):
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):
-        cls = self.__class__
-        for cat in getattr(cls, "_categories", []):
-            prop_name = cls._category_prop_map.get(cat)
-            expanded = getattr(self, prop_name)
-            panel = layout.box()
-            row = panel.row()
-            row.prop(self, prop_name, icon="TRIA_DOWN" if expanded else "TRIA_RIGHT", emboss=False, icon_only=True)
-            row.label(text=cat)
-            if expanded:
-                for attr, label, _socket, category in cls._prop_defs:
-                    if category == cat:
-                        panel.prop(self, attr, text=label)
-
-        for attr, label, _socket, category in cls._prop_defs:
-            if category is None:
-                layout.prop(self, attr, text=label)
+        pass
 
 
 build_props_and_sockets(

--- a/nodes/input.py
+++ b/nodes/input.py
@@ -32,8 +32,15 @@ class InputNode(BaseNode):
     vector_val: bpy.props.FloatVectorProperty(size=3, update=lambda self, ctx: self.update_socket_value())
     string_val: bpy.props.StringProperty(update=lambda self, ctx: self.update_socket_value())
 
+    expose_output: bpy.props.BoolProperty(
+        name="Expose Output",
+        default=True,
+        update=lambda self, ctx: self.update_socket_visibility(),
+    )
+
     def init(self, context):
         self.update_socket()
+        self.update_socket_visibility()
 
     def update_socket(self):
         while self.outputs:
@@ -48,6 +55,7 @@ class InputNode(BaseNode):
         stype = type_map.get(self.data_type, 'FloatSocketType')
         self.outputs.new(stype, "Value")
         self.update_socket_value()
+        self.update_socket_visibility()
 
     def update_socket_value(self):
         if not self.outputs:
@@ -65,14 +73,8 @@ class InputNode(BaseNode):
             sock.value = self.string_val
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, "data_type")
-        if self.data_type == 'FLOAT':
-            layout.prop(self, "float_val", text="Value")
-        elif self.data_type == 'INT':
-            layout.prop(self, "int_val", text="Value")
-        elif self.data_type == 'BOOL':
-            layout.prop(self, "bool_val", text="Value")
-        elif self.data_type == 'VECTOR':
-            layout.prop(self, "vector_val", text="Value")
-        elif self.data_type == 'STRING':
-            layout.prop(self, "string_val", text="Value")
+        pass
+
+    def update_socket_visibility(self):
+        if self.outputs:
+            self.outputs[0].hide = not self.expose_output

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,18 +1,22 @@
 # ui/__init__.py
 from .node_editor import SCENE_GRAPH_MT_add
 from .operators import NODE_OT_sync_to_scene
+from .node_panel import SCENE_GRAPH_PT_node_properties
 
 __all__ = [
     "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
+    "SCENE_GRAPH_PT_node_properties",
 ]
-from . import node_editor
+from . import node_editor, node_panel
 
 
 def register():
     node_editor.register()
+    node_panel.register()
 
 
 def unregister():
+    node_panel.unregister()
     node_editor.unregister()
 

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -1,0 +1,64 @@
+import bpy
+
+class SCENE_GRAPH_PT_node_properties(bpy.types.Panel):
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Node'
+    bl_label = 'Scene Node'
+
+    @classmethod
+    def poll(cls, context):
+        node = getattr(context, 'active_node', None)
+        return node is not None and hasattr(node, 'update_sockets')
+
+    def draw(self, context):
+        layout = self.layout
+        node = context.active_node
+        cls = node.__class__
+        if getattr(cls, '_prop_defs', []):
+            categories = getattr(cls, '_categories', [])
+            if categories:
+                for cat in categories:
+                    prop_name = cls._category_prop_map.get(cat)
+                    expanded = getattr(node, prop_name)
+                    box = layout.box()
+                    row = box.row()
+                    row.prop(node, prop_name, icon='TRIA_DOWN' if expanded else 'TRIA_RIGHT', emboss=False, icon_only=True)
+                    row.label(text=cat)
+                    if expanded:
+                        for attr, label, _socket, category in cls._prop_defs:
+                            if category == cat:
+                                row = box.row()
+                                row.prop(node, attr, text=label)
+                                expose = cls._expose_prop_map.get(attr)
+                                if expose:
+                                    row.prop(node, expose, text='Socket')
+            for attr, label, _socket, category in getattr(cls, '_prop_defs', []):
+                if category is None:
+                    row = layout.row()
+                    row.prop(node, attr, text=label)
+                    expose = cls._expose_prop_map.get(attr)
+                    if expose:
+                        row.prop(node, expose, text='Socket')
+        else:
+            if hasattr(node, 'data_type'):
+                layout.prop(node, 'data_type')
+                if node.data_type == 'FLOAT':
+                    layout.prop(node, 'float_val', text='Value')
+                elif node.data_type == 'INT':
+                    layout.prop(node, 'int_val', text='Value')
+                elif node.data_type == 'BOOL':
+                    layout.prop(node, 'bool_val', text='Value')
+                elif node.data_type == 'VECTOR':
+                    layout.prop(node, 'vector_val', text='Value')
+                elif node.data_type == 'STRING':
+                    layout.prop(node, 'string_val', text='Value')
+                layout.prop(node, 'expose_output')
+
+
+def register():
+    bpy.utils.register_class(SCENE_GRAPH_PT_node_properties)
+
+
+def unregister():
+    bpy.utils.unregister_class(SCENE_GRAPH_PT_node_properties)


### PR DESCRIPTION
## Summary
- expose socket toggles when defining node properties
- update nodes to hide/show sockets accordingly
- provide a new N‑panel to edit node options
- support toggling the output socket on the Input node
- register the new panel in the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed13cd1288330af9d4af388ce0b83