### PR TITLE
Switch node panel to exposure toggles

### DIFF
--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -17,11 +17,10 @@ class SCENE_GRAPH_PT_node_properties(bpy.types.Panel):
         cls = node.__class__
         if getattr(cls, '_prop_defs', []):
             for attr, label, _socket, *_ in getattr(cls, '_prop_defs', []):
-                row = layout.row()
-                row.prop(node, attr, text=label)
                 expose = cls._expose_prop_map.get(attr)
                 if expose:
-                    row.prop(node, expose, text='Socket')
+                    row = layout.row()
+                    row.prop(node, expose, text=label)
         else:
             if hasattr(node, 'data_type'):
                 layout.prop(node, 'data_type')


### PR DESCRIPTION
## Summary
- only show property exposure checkboxes in the node side panel
- keep socket inputs editable when visible

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f0246b5d483309303e1bff279af2c