### PR TITLE
Enable dynamic inputs on Group nodes

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -142,10 +142,16 @@ def _evaluate_transform(node, inputs, _scene=None):
     return node.scene_nodes_output
 
 
-def _evaluate_group(node, inputs, scene):
+def _evaluate_group(node, _inputs, scene):
     collection = bpy.data.collections.new(name=f"{node.name}_group")
     scene.collection.children.link(collection)
-    for coll in inputs:
+
+    for sock in node.inputs:
+        if sock.bl_idname != "SceneSocketType":
+            continue
+        coll = None
+        if sock.is_linked and sock.links:
+            coll = getattr(sock.links[0].from_node, "scene_nodes_output", None)
         if coll is None:
             continue
         for obj in coll.objects:

--- a/nodes/group.py
+++ b/nodes/group.py
@@ -5,10 +5,31 @@ class GroupNode(BaseNode):
     bl_idname = "GroupNodeType"
     bl_label = "Group"
 
+    num_inputs: bpy.props.IntProperty(
+        name="Inputs",
+        min=1,
+        default=2,
+        update=lambda self, ctx: self.update_sockets(),
+    )
+
     def init(self, context):
-        self.inputs.new('SceneSocketType', "Scene 1")
-        self.inputs.new('SceneSocketType', "Scene 2")
+        self.update_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
-    def draw_buttons(self, _context, _layout):
-        pass
+    def update_sockets(self):
+        """Ensure the correct number of Scene inputs exist."""
+        scene_inputs = [s for s in self.inputs if s.bl_idname == 'SceneSocketType']
+        # Add sockets if needed
+        while len(scene_inputs) < self.num_inputs:
+            idx = len(scene_inputs) + 1
+            scene_inputs.append(self.inputs.new('SceneSocketType', f"Scene {idx}"))
+        # Remove extra sockets
+        while len(scene_inputs) > self.num_inputs:
+            sock = scene_inputs.pop()
+            self.inputs.remove(sock)
+        # Rename sockets to keep them ordered
+        for idx, sock in enumerate(scene_inputs, 1):
+            sock.name = f"Scene {idx}"
+
+    def draw_buttons(self, context, layout):
+        layout.prop(self, "num_inputs")


### PR DESCRIPTION
## Summary
- allow `GroupNode` to manage a user-defined number of scene inputs
- iterate over every `SceneSocketType` input when evaluating Group nodes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f092e59448330aede6f5465a88ef4