### PR TITLE
Add dynamic property nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,9 @@ from .nodes.global_options import GlobalOptionsNode
 from .nodes.outputs_stub import OutputsStubNode
 from .nodes.scene_output import SceneOutputNode
 from .nodes.input import InputNode
+from .nodes.render_properties import RenderCyclesNode, RenderEeveeNode
+from .nodes.output_properties import OutputPropertiesNode
+from .nodes.scene_properties import ScenePropertiesNode
 
 # UI
 from .ui.node_categories import node_categories
@@ -52,6 +55,7 @@ classes = [
     StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
+    RenderCyclesNode, RenderEeveeNode, OutputPropertiesNode, ScenePropertiesNode,
     NODE_OT_sync_to_scene,
     SCENE_GRAPH_MT_add,
 ]

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -6,9 +6,13 @@ from .global_options import GlobalOptionsNode
 from .outputs_stub import OutputsStubNode
 from .scene_output import SceneOutputNode
 from .input import InputNode
+from .render_properties import RenderCyclesNode, RenderEeveeNode
+from .output_properties import OutputPropertiesNode
+from .scene_properties import ScenePropertiesNode
 
 __all__ = [
     "SceneInstanceNode", "TransformNode", "GroupNode",
     "LightNode", "GlobalOptionsNode", "OutputsStubNode",
-    "SceneOutputNode", "InputNode",
+    "SceneOutputNode", "InputNode", "RenderCyclesNode", "RenderEeveeNode",
+    "OutputPropertiesNode", "ScenePropertiesNode",
 ]

--- a/nodes/output_properties.py
+++ b/nodes/output_properties.py
@@ -1,0 +1,19 @@
+import bpy
+from .base import BaseNode
+from .property_utils import build_node_from_rna
+
+class OutputPropertiesNode(BaseNode):
+    bl_idname = "OutputPropertiesNodeType"
+    bl_label = "Output Properties"
+    property_group_path = ["render"]
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_node_from_rna(OutputPropertiesNode, bpy.types.RenderSettings)

--- a/nodes/property_utils.py
+++ b/nodes/property_utils.py
@@ -1,0 +1,52 @@
+import bpy
+from .base import build_props_and_sockets
+
+RNASocketMap = {
+    'BOOLEAN': 'BoolSocketType',
+    'INT': 'IntSocketType',
+    'FLOAT': 'FloatSocketType',
+    'FLOAT_VECTOR': 'VectorSocketType',
+    'STRING': 'StringSocketType',
+    'ENUM': 'StringSocketType',
+}
+
+RnaTypeMap = {
+    'BOOLEAN': 'bool',
+    'INT': 'int',
+    'FLOAT': 'float',
+    'FLOAT_VECTOR': 'vector',
+    'STRING': 'string',
+    'ENUM': 'enum',
+}
+
+
+def descriptors_from_rna(rna_struct, exclude=None):
+    """Build descriptors from a RNA struct."""
+    if exclude is None:
+        exclude = set()
+    descs = []
+    for prop in rna_struct.bl_rna.properties:
+        if prop.identifier in {'rna_type'} or prop.identifier in exclude:
+            continue
+        if getattr(prop, 'is_hidden', False) or getattr(prop, 'is_readonly', False):
+            continue
+        typ = RnaTypeMap.get(prop.type)
+        socket = RNASocketMap.get(prop.type)
+        if typ is None or socket is None:
+            continue
+        kwargs = {'name': prop.name}
+        if prop.type == 'ENUM':
+            items = []
+            for item in prop.enum_items:
+                items.append((item.identifier, item.name, item.description))
+            kwargs['items'] = items
+        if prop.type in {'FLOAT_VECTOR'}:
+            kwargs['size'] = prop.array_length
+        descs.append((prop.identifier, typ, kwargs))
+    return descs
+
+
+def build_node_from_rna(cls, rna_struct, exclude=None):
+    descs = descriptors_from_rna(rna_struct, exclude=exclude)
+    build_props_and_sockets(cls, descs)
+    return cls

--- a/nodes/render_properties.py
+++ b/nodes/render_properties.py
@@ -1,0 +1,36 @@
+import bpy
+from .base import BaseNode
+from .property_utils import build_node_from_rna
+
+class RenderCyclesNode(BaseNode):
+    bl_idname = "RenderCyclesNodeType"
+    bl_label = "Render Properties Cycles"
+    property_group_path = ["cycles"]
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_node_from_rna(RenderCyclesNode, bpy.types.CyclesRenderSettings)
+
+
+class RenderEeveeNode(BaseNode):
+    bl_idname = "RenderEeveeNodeType"
+    bl_label = "Render Properties EEVEE"
+    property_group_path = ["eevee"]
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_node_from_rna(RenderEeveeNode, bpy.types.EeveeRenderSettings if hasattr(bpy.types, 'EeveeRenderSettings') else bpy.types.Scene.eevee.__class__)

--- a/nodes/scene_properties.py
+++ b/nodes/scene_properties.py
@@ -1,0 +1,19 @@
+import bpy
+from .base import BaseNode
+from .property_utils import build_node_from_rna
+
+class ScenePropertiesNode(BaseNode):
+    bl_idname = "ScenePropertiesNodeType"
+    bl_label = "Scene Properties"
+    property_group_path = []
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.add_property_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_node_from_rna(ScenePropertiesNode, bpy.types.Scene)

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -15,6 +15,10 @@ node_categories = [
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),
         NodeItem("OutputsStubNodeType"),
+        NodeItem("RenderCyclesNodeType"),
+        NodeItem("RenderEeveeNodeType"),
+        NodeItem("OutputPropertiesNodeType"),
+        NodeItem("ScenePropertiesNodeType"),
         NodeItem("SceneOutputNodeType"),
     ])
 ]

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -14,6 +14,10 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"
         layout.operator("node.add_node", text="Render Outputs").type = "OutputsStubNodeType"
+        layout.operator("node.add_node", text="Render Cycles").type = "RenderCyclesNodeType"
+        layout.operator("node.add_node", text="Render EEVEE").type = "RenderEeveeNodeType"
+        layout.operator("node.add_node", text="Output Properties").type = "OutputPropertiesNodeType"
+        layout.operator("node.add_node", text="Scene Properties").type = "ScenePropertiesNodeType"
         layout.operator("node.add_node", text="Scene Output").type = "SceneOutputNodeType"
 
 def menu_draw(self, context):


### PR DESCRIPTION
## Summary
- add helper utilities to build nodes from RNA structs
- implement nodes for Render, Output, and Scene properties
- apply node properties generically during evaluation
- register new nodes in the add-on and UI

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f0b71f74c8330a73ec0c5828d5e93