### PR TITLE
Fix CyclesRenderSettings lookup

### DIFF
--- a/nodes/render_properties.py
+++ b/nodes/render_properties.py
@@ -60,7 +60,13 @@ def _build_engine_props(cls, engine, rna_struct):
     return cls
 
 
-_build_engine_props(RenderSettingsNode, 'CYCLES', bpy.types.CyclesRenderSettings)
+_build_engine_props(
+    RenderSettingsNode,
+    'CYCLES',
+    bpy.types.CyclesRenderSettings
+    if hasattr(bpy.types, 'CyclesRenderSettings')
+    else bpy.types.Scene.cycles.__class__,
+)
 _build_engine_props(
     RenderSettingsNode,
     'BLENDER_EEVEE',


### PR DESCRIPTION
## Summary
- support newer Blender by checking for `CyclesRenderSettings`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f105e2dd48330bd16d4e89e6752c8