### PR TITLE
Fix property update for RenderSettingsNode

### DIFF
--- a/nodes/render_properties.py
+++ b/nodes/render_properties.py
@@ -50,6 +50,10 @@ class RenderSettingsNode(BaseNode):
     _engine_prop_defs = []  # (attr_pref, rna_attr, label, socket_id, engine)
 
     def update_engine(self, context):
+        # During node creation the EnumProperty update callback can run before
+        # :func:`init` has had a chance to create ``_property_sockets``.
+        if not hasattr(self, "_property_sockets"):
+            return
         for attr, _rna, label, _sid, eng in self.__class__._engine_prop_defs:
             sock = self._property_sockets.get(attr)
             if sock:


### PR DESCRIPTION
## Summary
- avoid AttributeError in RenderSettingsNode when switching render engines before node initialization

## Testing
- `python -m py_compile nodes/render_properties.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684f226976dc8330aef200321cb1124b