### PR TITLE
Add togglable sockets and UI panel

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -75,11 +75,12 @@ def _collect_input_scenes(node):
 def _apply_node_properties(node, target):
     """Copy dynamic properties from *node* to *target*."""
     for attr, label, _ in getattr(node.__class__, '_prop_defs', []):
-        val = _socket_value(node, label, getattr(node, attr, None))
-        try:
-            setattr(target, attr, val)
-        except Exception:
-            pass
+        if getattr(node, f"use_{attr}", False):
+            val = _socket_value(node, label, getattr(node, attr, None))
+            try:
+                setattr(target, attr, val)
+            except Exception:
+                pass
 
 
 def _evaluate_scene_instance(node, _inputs, scene):

--- a/nodes/global_options.py
+++ b/nodes/global_options.py
@@ -6,6 +6,7 @@ class GlobalOptionsNode(BaseNode):
     bl_label = "Global Options"
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")

--- a/nodes/light.py
+++ b/nodes/light.py
@@ -6,6 +6,7 @@ class LightNode(BaseNode):
     bl_label = "Light"
 
     def init(self, context):
+        super().init(context)
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 

--- a/nodes/output_properties.py
+++ b/nodes/output_properties.py
@@ -8,6 +8,7 @@ class OutputPropertiesNode(BaseNode):
     property_group_path = ["render"]
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")

--- a/nodes/outputs_stub.py
+++ b/nodes/outputs_stub.py
@@ -6,6 +6,7 @@ class OutputsStubNode(BaseNode):
     bl_label = "Render Outputs"
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -6,6 +6,7 @@ class SceneInstanceNode(BaseNode):
     bl_label = "Scene Instance"
 
     def init(self, context):
+        super().init(context)
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 

--- a/nodes/scene_output.py
+++ b/nodes/scene_output.py
@@ -7,6 +7,7 @@ class SceneOutputNode(BaseNode):
     bl_label = "Scene Output"
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
 

--- a/nodes/scene_properties.py
+++ b/nodes/scene_properties.py
@@ -8,6 +8,7 @@ class ScenePropertiesNode(BaseNode):
     property_group_path = []
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -6,6 +6,7 @@ class TransformNode(BaseNode):
     bl_label = "Transform"
 
     def init(self, context):
+        super().init(context)
         self.inputs.new('SceneSocketType', "Scene")
         self.add_property_sockets()
         self.outputs.new('SceneSocketType', "Scene")

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,18 +1,23 @@
 # ui/__init__.py
+import bpy
 from .node_editor import SCENE_GRAPH_MT_add
 from .operators import NODE_OT_sync_to_scene
+from .property_panel import SCENE_GRAPH_PT_property_sockets
 
 __all__ = [
     "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
+    "SCENE_GRAPH_PT_property_sockets",
 ]
-from . import node_editor
+from . import node_editor, property_panel
 
 
 def register():
     node_editor.register()
+    bpy.utils.register_class(SCENE_GRAPH_PT_property_sockets)
 
 
 def unregister():
+    bpy.utils.unregister_class(SCENE_GRAPH_PT_property_sockets)
     node_editor.unregister()
 

--- a/ui/property_panel.py
+++ b/ui/property_panel.py
@@ -1,0 +1,24 @@
+import bpy
+from bpy.types import Panel
+from ..nodes.base import BaseNode
+
+
+class SCENE_GRAPH_PT_property_sockets(Panel):
+    bl_idname = "SCENE_GRAPH_PT_property_sockets"
+    bl_label = "Node Properties"
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Scene Nodes'
+
+    @classmethod
+    def poll(cls, context):
+        node = context.active_node
+        return isinstance(node, BaseNode)
+
+    def draw(self, context):
+        layout = self.layout
+        node = context.active_node
+        for attr, label, _sid in getattr(node.__class__, '_prop_defs', []):
+            prop_name = f"use_{attr}"
+            if hasattr(node, prop_name):
+                layout.prop(node, prop_name, text=label)


### PR DESCRIPTION
## Summary
- toggle property sockets with BoolProperties
- update BaseNode and nodes to support property socket toggling
- apply properties only when enabled during evaluation
- expose checkboxes in new Node Editor panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f2b1bcf388330bffdbb4e26c0b834