### PR TITLE
Fix BoolProperty update handler

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -108,10 +108,13 @@ def build_props_and_sockets(cls, descriptors):
         cls.__annotations__[attr] = prop
         label = kwargs.get('name', attr)
         cls._prop_defs.append((attr, label, socket_id))
+        def _update(self, ctx, attr=attr, sid=socket_id, label=label):
+            self.toggle_property_socket(attr, sid, label)
+
         bool_prop = bpy.props.BoolProperty(
             name=f"Use {label}",
             default=True,
-            update=lambda self, ctx, a=attr, sid=socket_id, l=label: self.toggle_property_socket(a, sid, l),
+            update=_update,
         )
         setattr(cls, f"use_{attr}", bool_prop)
         cls.__annotations__[f"use_{attr}"] = bool_prop


### PR DESCRIPTION
## Summary
- fix update callback for dynamically created BoolProperties so Blender registers them correctly

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fce165c83309cc0cb833dee58bd