### PR TITLE
Fix double registration of SceneNodeTree

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -64,7 +64,11 @@ NODETREE_CATEGORY = 'SCENE_NODES'
 
 def register():
     for cls in classes:
-        bpy.utils.register_class(cls)
+        try:
+            bpy.utils.register_class(cls)
+        except ValueError:
+            bpy.utils.unregister_class(cls)
+            bpy.utils.register_class(cls)
     register_node_categories(NODETREE_CATEGORY, node_categories)
     ui.register()
 


### PR DESCRIPTION
## Summary
- handle case where classes are already registered when enabling the add-on

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f30f7afcc8330ab916a69ff4ad5a9