### PR TITLE
Add socket enable flags and UI panel

### DIFF
--- a/nodes/global_options.py
+++ b/nodes/global_options.py
@@ -7,7 +7,7 @@ class GlobalOptionsNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        self.add_property_sockets()
+        self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):

--- a/nodes/light.py
+++ b/nodes/light.py
@@ -6,7 +6,7 @@ class LightNode(BaseNode):
     bl_label = "Light"
 
     def init(self, context):
-        self.add_property_sockets()
+        self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):

--- a/nodes/outputs_stub.py
+++ b/nodes/outputs_stub.py
@@ -7,7 +7,7 @@ class OutputsStubNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        self.add_property_sockets()
+        self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -6,7 +6,7 @@ class SceneInstanceNode(BaseNode):
     bl_label = "Scene Instance"
 
     def init(self, context):
-        self.add_property_sockets()
+        self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):

--- a/nodes/scene_output.py
+++ b/nodes/scene_output.py
@@ -8,7 +8,7 @@ class SceneOutputNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        self.add_property_sockets()
+        self.add_enabled_sockets()
 
     def draw_buttons(self, context, layout):
         pass

--- a/nodes/transform.py
+++ b/nodes/transform.py
@@ -7,7 +7,7 @@ class TransformNode(BaseNode):
 
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
-        self.add_property_sockets()
+        self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
 
     def draw_buttons(self, context, layout):

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,18 +1,23 @@
 # ui/__init__.py
 from .node_editor import SCENE_GRAPH_MT_add
 from .operators import NODE_OT_sync_to_scene
+from .node_panel import SCENE_NODES_PT_node_props
 
 __all__ = [
     "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
+    "SCENE_NODES_PT_node_props",
 ]
 from . import node_editor
+from . import node_panel
 
 
 def register():
     node_editor.register()
+    node_panel.register()
 
 
 def unregister():
     node_editor.unregister()
+    node_panel.unregister()
 

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -1,0 +1,32 @@
+import bpy
+
+class SCENE_NODES_PT_node_props(bpy.types.Panel):
+    bl_idname = "SCENE_NODES_PT_node_props"
+    bl_label = "Node Properties"
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Item'
+
+    @classmethod
+    def poll(cls, context):
+        space = context.space_data
+        return (
+            space is not None
+            and space.tree_type == 'SceneNodeTreeType'
+            and context.active_node is not None
+        )
+
+    def draw(self, context):
+        node = context.active_node
+        layout = self.layout
+        for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
+            prop_name = f"use_{attr}"
+            if hasattr(node, prop_name):
+                layout.prop(node, prop_name, text=label)
+
+def register():
+    bpy.utils.register_class(SCENE_NODES_PT_node_props)
+
+
+def unregister():
+    bpy.utils.unregister_class(SCENE_NODES_PT_node_props)


### PR DESCRIPTION
## Summary
- create BoolProperties for each node property and toggle sockets accordingly
- add helpers in `BaseNode` to manage sockets
- only create sockets for enabled properties in node classes
- add UI panel to toggle property usage
- check `use_` flags in evaluator before applying changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f3a0cae388330ab1f378a97342612