### PR TITLE
Fix missing properties in node panel

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -99,23 +99,24 @@ def build_props_and_sockets(cls, descriptors):
         directly to ``bpy.props``.
     """
     cls._prop_defs = []
+    annotations = cls.__dict__.setdefault("__annotations__", {})
     for attr, typ, kwargs in descriptors:
         prop_fn, socket_id = PROPERTY_SOCKET_MAP[typ]
-        setattr(cls, attr, prop_fn(**kwargs))
+        prop = prop_fn(**kwargs)
+        setattr(cls, attr, prop)
+        annotations[attr] = prop
         label = kwargs.get("name", attr)
         cls._prop_defs.append((attr, label, socket_id))
 
         # Boolean property controlling the socket visibility
         bool_name = f"use_{attr}"
-        setattr(
-            cls,
-            bool_name,
-            bpy.props.BoolProperty(
-                name=f"Use {label}",
-                default=True,
-                update=lambda self, ctx, a=attr: self.update_socket_visibility(a),
-            ),
+        bool_prop = bpy.props.BoolProperty(
+            name=f"Use {label}",
+            default=True,
+            update=lambda self, ctx, a=attr: self.update_socket_visibility(a),
         )
+        setattr(cls, bool_name, bool_prop)
+        annotations[bool_name] = bool_prop
     return cls
 
 


### PR DESCRIPTION
## Summary
- ensure that `build_props_and_sockets` registers properties through class annotations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f3cb0eef883308069bf7b3e5ac0ca