### PR TITLE
Fix update callback registration error

### DIFF
--- a/nodes/base.py
+++ b/nodes/base.py
@@ -115,10 +115,15 @@ def build_props_and_sockets(cls, descriptors):
 
         # Boolean property controlling the socket visibility
         bool_name = f"use_{attr}"
+        def _make_update(name):
+            def _update(self, ctx):
+                self.update_socket_visibility(name)
+            return _update
+
         bool_prop = bpy.props.BoolProperty(
             name=f"Use {label}",
             default=True,
-            update=lambda self, ctx, a=attr: self.update_socket_visibility(a),
+            update=_make_update(attr),
         )
         setattr(cls, bool_name, bool_prop)
         annotations[bool_name] = bool_prop


### PR DESCRIPTION
## Summary
- fix update callback signature for BoolProperty

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f40797b2483308f1242584d1ed74d