### PR TITLE
Clarify node merge behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ tree.links.new(inst.outputs[0], out.inputs[0])
 # Evaluate the tree (applies changes to the scene)
 evaluate_scene_tree(tree)
 ```
+
+## Evaluation Order
+
+`Group` nodes merge only the objects from their connected scenes. Render and
+output options defined in upstream nodes are applied sequentially so nodes
+closer to **Scene Output** override earlier values. This mirrors how tools such
+as [Gaffer](https://gafferhq.org/) resolve conflicts: the last node in the
+chain wins.

--- a/documentation.txt
+++ b/documentation.txt
@@ -101,4 +101,14 @@ evaluación del árbol aplica los cambios directamente en la escena de Blender e
 lugar de limitarse a imprimir información en la consola. Sirve como base para
 futuros flujos de trabajo nodales de ensamblaje de escenas.
 
+Notas sobre la evaluación
+-------------------------
+- **Group** solo fusiona los objetos de las escenas conectadas. Otros datos,
+  como las opciones de render, no se combinan automáticamente.
+- Las opciones de render o salida establecidas en nodos como **Global
+  Options** o **Render Outputs** se aplican siguiendo el orden de evaluación.
+  Si varios nodos modifican el mismo valor, prevalece el que esté más cerca de
+  **Scene Output**, del mismo modo que hacen herramientas como *Gaffer*, donde
+  el nodo final de la cadena es el que manda.
+
 ---


### PR DESCRIPTION
## Summary
- document that `Group` nodes only merge objects
- explain that render/output nodes override earlier settings
- mention Gaffer's similar approach

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f4909d38883308b7f130499f80c96