### PR TITLE
Update node property panels

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,12 +1,16 @@
 # ui/__init__.py
 from .node_editor import SCENE_GRAPH_MT_add
 from .operators import NODE_OT_sync_to_scene
-from .node_panel import SCENE_NODES_PT_node_props
+from .node_panel import (
+    SCENE_NODES_PT_node_props,
+    SCENE_NODES_PT_node_props_properties,
+)
 
 __all__ = [
     "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
     "SCENE_NODES_PT_node_props",
+    "SCENE_NODES_PT_node_props_properties",
 ]
 from . import node_editor
 from . import node_panel

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -5,7 +5,7 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
     bl_label = "Node Properties"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
-    bl_category = 'Item'
+    bl_category = 'Node'
 
     @classmethod
     def poll(cls, context):
@@ -24,9 +24,17 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
             if hasattr(node, prop_name):
                 layout.prop(node, prop_name, text=label)
 
+
+class SCENE_NODES_PT_node_props_properties(SCENE_NODES_PT_node_props):
+    bl_idname = "SCENE_NODES_PT_node_props_properties"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+
 def register():
     bpy.utils.register_class(SCENE_NODES_PT_node_props)
+    bpy.utils.register_class(SCENE_NODES_PT_node_props_properties)
 
 
 def unregister():
+    bpy.utils.unregister_class(SCENE_NODES_PT_node_props_properties)
     bpy.utils.unregister_class(SCENE_NODES_PT_node_props)


### PR DESCRIPTION
## Summary
- show node properties panel under the *Node* tab in the Node Editor
- allow showing node properties in the Properties Editor

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m py_compile ui/node_panel.py`

------
https://chatgpt.com/codex/tasks/task_e_684f4ba91b1083308f9300e0f81983a4