### PR TITLE
Fix node properties panel poll

### DIFF
--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -10,9 +10,10 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         space = context.space_data
+        tree_type = getattr(space, "tree_type", None)
         return (
             space is not None
-            and space.tree_type == 'SceneNodeTreeType'
+            and tree_type == 'SceneNodeTreeType'
             and context.active_node is not None
         )
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when polling `SCENE_NODES_PT_node_props`

## Testing
- `python -m py_compile __init__.py node_tree.py engine/*.py nodes/*.py ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f4cf382208330bbb10fe0d41cbeaf