### PR TITLE
Fix node props panel visibility

### DIFF
--- a/documentation.txt
+++ b/documentation.txt
@@ -90,6 +90,11 @@ Puedes conectar estos sockets entre distintos nodos para compartir el mismo
 valor. Si un socket está enlazado, el nodo tomará el valor de la conexión;
 de lo contrario utilizará el valor interno editable en el propio nodo.
 
+Para controlar qué sockets se muestran, selecciona un nodo y abre la barra
+lateral del Node Editor con **N**. En la pestaña **Node** encontrarás el panel
+**Node Properties** con casillas "Use ..." que activan o desactivan los
+sockets correspondientes.
+
 Flujo de trabajo recomendado
 ---------------------------
 1. Empieza con nodos **Scene Properties** y **Render Properties** para configurar la escena.

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -9,13 +9,8 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        space = context.space_data
-        tree_type = getattr(space, "tree_type", None)
-        return (
-            space is not None
-            and tree_type == 'SceneNodeTreeType'
-            and context.active_node is not None
-        )
+        node = context.active_node
+        return node is not None and hasattr(node.__class__, "_prop_defs")
 
     def draw(self, context):
         node = context.active_node


### PR DESCRIPTION
## Summary
- fix poll method for node properties panel
- document how to show socket toggles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f4e77c5b88330965c5b85721c99a6