### PR TITLE
Enable editing of unlinked socket values

### DIFF
--- a/documentation.txt
+++ b/documentation.txt
@@ -93,7 +93,8 @@ de lo contrario utilizará el valor interno editable en el propio nodo.
 Para controlar qué sockets se muestran, selecciona un nodo y abre la barra
 lateral del Node Editor con **N**. En la pestaña **Node** encontrarás el panel
 **Node Properties** con casillas "Use ..." que activan o desactivan los
-sockets correspondientes.
+sockets correspondientes. Si el socket está activo pero sin ninguna conexión,
+su valor puede modificarse directamente desde este panel.
 
 Flujo de trabajo recomendado
 ---------------------------

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -22,8 +22,16 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
         layout = self.layout
         for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
             prop_name = f"use_{attr}"
-            if hasattr(node, prop_name):
-                layout.prop(node, prop_name, text=label)
+            if not hasattr(node, prop_name):
+                continue
+
+            row = layout.row(align=True)
+            row.prop(node, prop_name, text=label, toggle=True)
+
+            if getattr(node, prop_name):
+                sock = node.inputs.get(label)
+                if sock is not None and not sock.is_linked:
+                    row.prop(sock, "value", text="")
 
 
 class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
@@ -47,8 +55,16 @@ class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
         layout = self.layout
         for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
             prop_name = f"use_{attr}"
-            if hasattr(node, prop_name):
-                layout.prop(node, prop_name, text=label)
+            if not hasattr(node, prop_name):
+                continue
+
+            row = layout.row(align=True)
+            row.prop(node, prop_name, text=label, toggle=True)
+
+            if getattr(node, prop_name):
+                sock = node.inputs.get(label)
+                if sock is not None and not sock.is_linked:
+                    row.prop(sock, "value", text="")
 
 
 class SCENE_NODES_PT_node_props_properties(SCENE_NODES_PT_node_props):


### PR DESCRIPTION
## Summary
- allow editing socket values from addon panel when sockets are enabled but unlinked
- document that active unlinked sockets can be adjusted from the Node Properties panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f54a0b0b88330a8614dd6acc09018