### PR TITLE
Improve node property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Experimental node-based system for assembling Blender scenes.
 
 After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 
+## New in this version
+
+- Render Properties node now adjusts its parameters depending on the selected render engine.
+- Scene and Output nodes expose additional settings such as frame range, FPS and color mode.
+
 ## Usage
 
 1. Open the Node Editor and change the tree type to **Scene Graph**.

--- a/documentation.txt
+++ b/documentation.txt
@@ -67,17 +67,22 @@ Crea una luz en la escena.
 ### Scene Properties
 Define opciones generales de la escena.
 - **Resolution X/Y**: resolución de render.
+- **Frame Start/End**: rango de cuadros para la animación.
+- **FPS**: fotogramas por segundo.
 - **Camera Path**: ruta a una cámara existente en el archivo.
 
 ### Render Properties
 Ajustes del motor de render y el muestreo.
 - **Engine**: motor de render (Eevee, Cycles o Workbench).
 - **Samples**: número de muestras para el render.
+- **Motion Blur** (Eevee): habilitar desenfoque de movimiento.
+- **Max Bounces** (Cycles): número máximo de rebotes de la luz.
 
 ### Output Properties
 Establece datos básicos de salida.
 - **File Path**: carpeta o archivo de destino.
 - **Format**: formato de imagen (OpenEXR o PNG).
+- **Color**: modo de color de la imagen.
 
 ### Scene Output
 Define el nombre de la escena resultante. Debe situarse al final del 

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -247,6 +247,15 @@ def _evaluate_scene_properties(node, _inputs, scene):
         res_y = _socket_value(node, "Resolution Y", getattr(node, "res_y", 1080))
         scene.render.resolution_y = res_y
 
+    if getattr(node, "use_frame_start", False):
+        scene.frame_start = _socket_value(node, "Frame Start", getattr(node, "frame_start", scene.frame_start))
+
+    if getattr(node, "use_frame_end", False):
+        scene.frame_end = _socket_value(node, "Frame End", getattr(node, "frame_end", scene.frame_end))
+
+    if getattr(node, "use_fps", False):
+        scene.render.fps = _socket_value(node, "FPS", getattr(node, "fps", scene.render.fps))
+
     if getattr(node, "use_camera_path", False):
         camera_path = _socket_value(node, "Camera Path", getattr(node, "camera_path", ""))
         if camera_path in bpy.data.objects:
@@ -260,11 +269,24 @@ def _evaluate_render_properties(node, _inputs, scene):
     if getattr(node, "use_engine", False):
         engine = _socket_value(node, "Engine", getattr(node, "engine", "BLENDER_EEVEE"))
         scene.render.engine = engine
+    else:
+        engine = scene.render.engine
 
-    if getattr(node, "use_samples", False):
-        samples = _socket_value(node, "Samples", getattr(node, "samples", 128))
-        scene.cycles.samples = samples if hasattr(scene, "cycles") else samples
-
+    if engine == "CYCLES":
+        if getattr(node, "use_samples", False):
+            samples = _socket_value(node, "Samples", getattr(node, "samples", 64))
+            scene.cycles.samples = samples
+        if getattr(node, "use_max_bounces", False):
+            mb = _socket_value(node, "Max Bounces", getattr(node, "max_bounces", 8))
+            scene.cycles.max_bounces = mb
+    elif engine == "BLENDER_EEVEE":
+        if getattr(node, "use_samples", False):
+            samples = _socket_value(node, "Samples", getattr(node, "samples", 64))
+            scene.eevee.taa_render_samples = samples
+        if getattr(node, "use_motion_blur", False):
+            blur = _socket_value(node, "Motion Blur", getattr(node, "motion_blur", False))
+            scene.eevee.use_motion_blur = blur
+    
     node.scene_nodes_output = scene.collection
     return node.scene_nodes_output
 
@@ -277,6 +299,10 @@ def _evaluate_output_properties(node, _inputs, scene):
     if getattr(node, "use_file_format", False):
         fmt = _socket_value(node, "Format", getattr(node, "file_format", "OPEN_EXR"))
         scene.render.image_settings.file_format = fmt
+
+    if getattr(node, "use_color_mode", False):
+        mode = _socket_value(node, "Color", getattr(node, "color_mode", "RGB"))
+        scene.render.image_settings.color_mode = mode
 
     node.scene_nodes_output = scene.collection
     return node.scene_nodes_output

--- a/nodes/base.py
+++ b/nodes/base.py
@@ -206,3 +206,7 @@ class BaseNode(Node):
         for attr, _label, _socket in getattr(self.__class__, "_prop_defs", []):
             if getattr(self, f"use_{attr}", False):
                 self.add_property_socket(attr)
+
+    def is_property_visible(self, _attr):
+        """Override in subclasses to hide properties from the panels."""
+        return True

--- a/nodes/output_properties.py
+++ b/nodes/output_properties.py
@@ -30,5 +30,18 @@ build_props_and_sockets(
                 "name": "Format",
             },
         ),
+        (
+            "color_mode",
+            "enum",
+            {
+                "name": "Color",
+                "items": [
+                    ("BW", "BW", ""),
+                    ("RGB", "RGB", ""),
+                    ("RGBA", "RGBA", ""),
+                ],
+                "default": "RGB",
+            },
+        ),
     ],
 )

--- a/nodes/render_properties.py
+++ b/nodes/render_properties.py
@@ -6,13 +6,34 @@ class RenderPropertiesNode(BaseNode):
     bl_idname = "RenderPropertiesNodeType"
     bl_label = "Render Properties"
 
+    def update_engine(self, _context=None):
+        if self.engine == "BLENDER_EEVEE":
+            self.remove_property_socket("max_bounces")
+            if getattr(self, "use_motion_blur", False):
+                self.add_property_socket("motion_blur")
+        elif self.engine == "CYCLES":
+            self.remove_property_socket("motion_blur")
+            if getattr(self, "use_max_bounces", False):
+                self.add_property_socket("max_bounces")
+        else:
+            self.remove_property_socket("motion_blur")
+            self.remove_property_socket("max_bounces")
+
     def init(self, context):
         self.inputs.new('SceneSocketType', "Scene")
         self.add_enabled_sockets()
         self.outputs.new('SceneSocketType', "Scene")
+        self.update_engine()
 
     def draw_buttons(self, context, layout):
         pass  # Inputs already expose editable values next to their sockets
+
+    def is_property_visible(self, attr):
+        if attr == "motion_blur":
+            return self.engine == "BLENDER_EEVEE"
+        if attr == "max_bounces":
+            return self.engine == "CYCLES"
+        return True
 
 
 build_props_and_sockets(
@@ -29,8 +50,11 @@ build_props_and_sockets(
                     ("BLENDER_WORKBENCH", "Workbench", ""),
                 ],
                 "default": "BLENDER_EEVEE",
+                "update": lambda self, ctx: self.update_engine(),
             },
         ),
-        ("samples", "int", {"name": "Samples", "default": 128}),
+        ("samples", "int", {"name": "Samples", "default": 64}),
+        ("motion_blur", "bool", {"name": "Motion Blur"}),
+        ("max_bounces", "int", {"name": "Max Bounces", "default": 8}),
     ],
 )

--- a/nodes/scene_properties.py
+++ b/nodes/scene_properties.py
@@ -20,6 +20,9 @@ build_props_and_sockets(
     [
         ("res_x", "int", {"name": "Resolution X", "default": 1920}),
         ("res_y", "int", {"name": "Resolution Y", "default": 1080}),
+        ("frame_start", "int", {"name": "Frame Start", "default": 1}),
+        ("frame_end", "int", {"name": "Frame End", "default": 250}),
+        ("fps", "int", {"name": "FPS", "default": 24}),
         ("camera_path", "string", {"name": "Camera Path"}),
     ],
 )

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -21,6 +21,8 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
             node = getattr(context, "node", None)
         layout = self.layout
         for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
+            if hasattr(node, "is_property_visible") and not node.is_property_visible(attr):
+                continue
             prop_name = f"use_{attr}"
             if not hasattr(node, prop_name):
                 continue
@@ -54,6 +56,8 @@ class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
             node = getattr(context, "node", None)
         layout = self.layout
         for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
+            if hasattr(node, "is_property_visible") and not node.is_property_visible(attr):
+                continue
             prop_name = f"use_{attr}"
             if not hasattr(node, prop_name):
                 continue


### PR DESCRIPTION
## Summary
- expand Scene/Render/Output property nodes
- handle engine specific settings and socket visibility
- hide properties in the UI when not applicable
- document new options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f5beda980833085c0192cb5901d51