### PR TITLE
Fix Add menu duplicates and dynamic render engine properties

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,7 +37,6 @@ from .nodes.output_properties import OutputPropertiesNode
 
 # UI
 from .ui.node_categories import node_categories
-from .ui.node_editor import SCENE_GRAPH_MT_add
 from .ui.operators import NODE_OT_sync_to_scene
 from . import ui
 
@@ -57,7 +56,6 @@ classes = [
     LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
     ScenePropertiesNode, RenderPropertiesNode, OutputPropertiesNode,
     NODE_OT_sync_to_scene,
-    SCENE_GRAPH_MT_add,
 ]
 
 NODETREE_CATEGORY = 'SCENE_NODES'

--- a/nodes/base.py
+++ b/nodes/base.py
@@ -111,7 +111,7 @@ def build_props_and_sockets(cls, descriptors):
         setattr(cls, attr, prop)
         annotations[attr] = prop
         label = kwargs.get("name", attr)
-        cls._prop_defs.append((attr, label, socket_id))
+        cls._prop_defs.append((attr, label, socket_id, typ))
 
         # Boolean property controlling the socket visibility
         bool_name = f"use_{attr}"
@@ -139,21 +139,21 @@ class BaseNode(Node):
 
     def add_property_sockets(self):
         """Instantiate sockets for all defined properties."""
-        for attr, _label, _socket in getattr(self.__class__, "_prop_defs", []):
+        for attr, _label, _socket, _typ in getattr(self.__class__, "_prop_defs", []):
             self.add_property_socket(attr)
 
     # ------------------------------------------------------------------
     # Socket management helpers
     # ------------------------------------------------------------------
     def _find_prop_def(self, attr):
-        for a, label, socket in getattr(self.__class__, "_prop_defs", []):
+        for a, label, socket, typ in getattr(self.__class__, "_prop_defs", []):
             if a == attr:
-                return label, socket
-        return None, None
+                return label, socket, typ
+        return None, None, None
 
     def add_property_socket(self, attr):
         """Add the socket corresponding to *attr* if it doesn't exist."""
-        label, socket = self._find_prop_def(attr)
+        label, socket, _typ = self._find_prop_def(attr)
         if label is None:
             return
         if self.inputs.get(label) is not None:
@@ -168,7 +168,7 @@ class BaseNode(Node):
         new_index = len(self.inputs) - 1
         order_map = {
             lbl: idx
-            for idx, (_a, lbl, _s) in enumerate(
+            for idx, (_a, lbl, _s, _t) in enumerate(
                 getattr(self.__class__, "_prop_defs", [])
             )
         }
@@ -187,7 +187,7 @@ class BaseNode(Node):
 
     def remove_property_socket(self, attr):
         """Remove the socket corresponding to *attr* if present."""
-        label, _socket = self._find_prop_def(attr)
+        label, _socket, _typ = self._find_prop_def(attr)
         if label is None:
             return
         sock = self.inputs.get(label)
@@ -203,7 +203,7 @@ class BaseNode(Node):
 
     def add_enabled_sockets(self):
         """Instantiate sockets only for properties with their use flag enabled."""
-        for attr, _label, _socket in getattr(self.__class__, "_prop_defs", []):
+        for attr, _label, _socket, _typ in getattr(self.__class__, "_prop_defs", []):
             if getattr(self, f"use_{attr}", False):
                 self.add_property_socket(attr)
 

--- a/nodes/render_properties.py
+++ b/nodes/render_properties.py
@@ -7,6 +7,9 @@ class RenderPropertiesNode(BaseNode):
     bl_label = "Render Properties"
 
     def update_engine(self, _context=None):
+        sock = self.inputs.get("Engine")
+        if sock is not None:
+            sock.value = self.engine
         if self.engine == "BLENDER_EEVEE":
             self.remove_property_socket("max_bounces")
             if getattr(self, "use_motion_blur", False):

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,5 +1,4 @@
 # ui/__init__.py
-from .node_editor import SCENE_GRAPH_MT_add
 from .operators import NODE_OT_sync_to_scene
 from .node_panel import (
     SCENE_NODES_PT_node_props,
@@ -8,22 +7,18 @@ from .node_panel import (
 )
 
 __all__ = [
-    "SCENE_GRAPH_MT_add",
     "NODE_OT_sync_to_scene",
     "SCENE_NODES_PT_node_props",
     "SCENE_NODES_PT_node_props_properties",
     "SCENE_NODES_PT_socket_visibility",
 ]
-from . import node_editor
 from . import node_panel
 
 
 def register():
-    node_editor.register()
     node_panel.register()
 
 
 def unregister():
-    node_editor.unregister()
     node_panel.unregister()
 

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -20,7 +20,7 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
         if node is None:
             node = getattr(context, "node", None)
         layout = self.layout
-        for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
+        for attr, label, _socket, typ in getattr(node.__class__, '_prop_defs', []):
             if hasattr(node, "is_property_visible") and not node.is_property_visible(attr):
                 continue
             prop_name = f"use_{attr}"
@@ -33,7 +33,12 @@ class SCENE_NODES_PT_node_props(bpy.types.Panel):
             if getattr(node, prop_name):
                 sock = node.inputs.get(label)
                 if sock is not None and not sock.is_linked:
-                    row.prop(sock, "value", text="")
+                    if typ == "enum":
+                        row.prop(node, attr, text="")
+                        if getattr(node, attr) != sock.value:
+                            sock.value = getattr(node, attr)
+                    else:
+                        row.prop(sock, "value", text="")
 
 
 class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
@@ -55,7 +60,7 @@ class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
         if node is None:
             node = getattr(context, "node", None)
         layout = self.layout
-        for attr, label, _socket in getattr(node.__class__, '_prop_defs', []):
+        for attr, label, _socket, typ in getattr(node.__class__, '_prop_defs', []):
             if hasattr(node, "is_property_visible") and not node.is_property_visible(attr):
                 continue
             prop_name = f"use_{attr}"
@@ -68,7 +73,12 @@ class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
             if getattr(node, prop_name):
                 sock = node.inputs.get(label)
                 if sock is not None and not sock.is_linked:
-                    row.prop(sock, "value", text="")
+                    if typ == "enum":
+                        row.prop(node, attr, text="")
+                        if getattr(node, attr) != sock.value:
+                            sock.value = getattr(node, attr)
+                    else:
+                        row.prop(sock, "value", text="")
 
 
 class SCENE_NODES_PT_node_props_properties(SCENE_NODES_PT_node_props):


### PR DESCRIPTION
## Summary
- remove custom add menu to avoid duplicate node listings
- track property types to enable enum handling
- sync Render Properties node's engine socket with dropdown changes
- update UI to show enum properties properly

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f6257f0b883309afb2d9b315082b5