### PR TITLE
Add Join/Split String nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 
 - Render Properties node now adjusts its parameters depending on the selected render engine.
 - Scene and Output nodes expose additional settings such as frame range, FPS and color mode.
+- Added **Join String** and **Split String** nodes for basic text manipulation.
 
 ## Usage
 

--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,8 @@ from .nodes.global_options import GlobalOptionsNode
 from .nodes.outputs_stub import OutputsStubNode
 from .nodes.scene_output import SceneOutputNode
 from .nodes.input import InputNode
+from .nodes.join_string import JoinStringNode
+from .nodes.split_string import SplitStringNode
 from .nodes.scene_properties import ScenePropertiesNode
 from .nodes.render_properties import RenderPropertiesNode
 from .nodes.output_properties import OutputPropertiesNode
@@ -54,6 +56,7 @@ classes = [
     StringSocket,
     SceneInstanceNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
+    JoinStringNode, SplitStringNode,
     ScenePropertiesNode, RenderPropertiesNode, OutputPropertiesNode,
     NODE_OT_sync_to_scene,
 ]

--- a/documentation.txt
+++ b/documentation.txt
@@ -64,6 +64,17 @@ Crea una luz en la escena.
 - **Energy**: potencia de la luz.
 - **Color**: color de la luz.
 
+### Join String
+Concatena dos textos usando un delimitador.
+- **String 1**: primera cadena.
+- **String 2**: segunda cadena.
+- **Delimiter**: texto a insertar entre ambas.
+
+### Split String
+Divide un texto en dos partes según un separador.
+- **String**: cadena a dividir.
+- **Separator**: separador utilizado para la división.
+
 ### Scene Properties
 Define opciones generales de la escena.
 - **Resolution X/Y**: resolución de render.

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -320,6 +320,55 @@ def _evaluate_outputs_stub(node, _inputs, scene):
     return node.scene_nodes_output
 
 
+def _evaluate_join_string(node, _inputs, _scene):
+    s1 = (
+        _socket_value(node, "String 1", getattr(node, "string1", ""))
+        if getattr(node, "use_string1", False)
+        else getattr(node, "string1", "")
+    )
+    s2 = (
+        _socket_value(node, "String 2", getattr(node, "string2", ""))
+        if getattr(node, "use_string2", False)
+        else getattr(node, "string2", "")
+    )
+    delim = (
+        _socket_value(node, "Delimiter", getattr(node, "delimiter", ""))
+        if getattr(node, "use_delimiter", False)
+        else getattr(node, "delimiter", "")
+    )
+    result = delim.join([s1, s2]) if delim else s1 + s2
+    out = node.outputs.get("String")
+    if out is not None:
+        out.value = result
+    node.scene_nodes_output = None
+    return None
+
+
+def _evaluate_split_string(node, _inputs, _scene):
+    text = (
+        _socket_value(node, "String", getattr(node, "string", ""))
+        if getattr(node, "use_string", False)
+        else getattr(node, "string", "")
+    )
+    sep = (
+        _socket_value(node, "Separator", getattr(node, "separator", ""))
+        if getattr(node, "use_separator", False)
+        else getattr(node, "separator", "")
+    )
+    parts = text.split(sep, 1) if sep else [text]
+    first = parts[0] if parts else ""
+    second = parts[1] if len(parts) > 1 else ""
+    if node.outputs:
+        out1 = node.outputs.get("Part 1")
+        if out1 is not None:
+            out1.value = first
+        out2 = node.outputs.get("Part 2")
+        if out2 is not None:
+            out2.value = second
+    node.scene_nodes_output = None
+    return None
+
+
 def _evaluate_input(node, _inputs, _scene):
     node.scene_nodes_output = None
     return None
@@ -355,6 +404,10 @@ def _evaluate_node(node, scene):
         return _evaluate_scene_output(node, inputs, scene)
     elif ntype == "InputNodeType":
         return _evaluate_input(node, inputs, scene)
+    elif ntype == "JoinStringNodeType":
+        return _evaluate_join_string(node, inputs, scene)
+    elif ntype == "SplitStringNodeType":
+        return _evaluate_split_string(node, inputs, scene)
     else:
         print(f"[scene_nodes] unknown node type {ntype}")
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -6,6 +6,8 @@ from .global_options import GlobalOptionsNode
 from .outputs_stub import OutputsStubNode
 from .scene_output import SceneOutputNode
 from .input import InputNode
+from .join_string import JoinStringNode
+from .split_string import SplitStringNode
 from .scene_properties import ScenePropertiesNode
 from .render_properties import RenderPropertiesNode
 from .output_properties import OutputPropertiesNode
@@ -15,4 +17,5 @@ __all__ = [
     "LightNode", "GlobalOptionsNode", "OutputsStubNode",
     "SceneOutputNode", "InputNode", "ScenePropertiesNode",
     "RenderPropertiesNode", "OutputPropertiesNode",
+    "JoinStringNode", "SplitStringNode",
 ]

--- a/nodes/join_string.py
+++ b/nodes/join_string.py
@@ -1,0 +1,24 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class JoinStringNode(BaseNode):
+    bl_idname = "JoinStringNodeType"
+    bl_label = "Join String"
+
+    def init(self, context):
+        self.add_enabled_sockets()
+        self.outputs.new('StringSocketType', "String")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_props_and_sockets(
+    JoinStringNode,
+    [
+        ("string1", "string", {"name": "String 1"}),
+        ("string2", "string", {"name": "String 2"}),
+        ("delimiter", "string", {"name": "Delimiter"}),
+    ],
+)

--- a/nodes/split_string.py
+++ b/nodes/split_string.py
@@ -1,0 +1,24 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class SplitStringNode(BaseNode):
+    bl_idname = "SplitStringNodeType"
+    bl_label = "Split String"
+
+    def init(self, context):
+        self.add_enabled_sockets()
+        self.outputs.new('StringSocketType', "Part 1")
+        self.outputs.new('StringSocketType', "Part 2")
+
+    def draw_buttons(self, context, layout):
+        pass
+
+
+build_props_and_sockets(
+    SplitStringNode,
+    [
+        ("string", "string", {"name": "String"}),
+        ("separator", "string", {"name": "Separator"}),
+    ],
+)

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -11,6 +11,8 @@ node_categories = [
         NodeItem("SceneInstanceNodeType"),
         NodeItem("TransformNodeType"),
         NodeItem("InputNodeType"),
+        NodeItem("JoinStringNodeType"),
+        NodeItem("SplitStringNodeType"),
         NodeItem("GroupNodeType"),
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -10,6 +10,8 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Scene Instance").type = "SceneInstanceNodeType"
         layout.operator("node.add_node", text="Transform").type = "TransformNodeType"
         layout.operator("node.add_node", text="Input").type = "InputNodeType"
+        layout.operator("node.add_node", text="Join String").type = "JoinStringNodeType"
+        layout.operator("node.add_node", text="Split String").type = "SplitStringNodeType"
         layout.operator("node.add_node", text="Group").type = "GroupNodeType"
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"


### PR DESCRIPTION
## Summary
- add JoinStringNode and SplitStringNode
- export and register new nodes
- show new nodes in the UI menus
- handle new nodes in evaluator
- document usage in docs and README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fb17b93588330bc8b819483d09271