### PR TITLE
Add Alembic import node

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 - Scene and Output nodes expose additional settings such as frame range, FPS and color mode.
 - Added **Join String** and **Split String** nodes for basic text manipulation.
 - New **Cycles Attributes** node lets you edit Cycles visibility flags with optional filtering.
+- Added **Alembic Import** node to load `.abc` files directly.
 
 ## Usage
 

--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,7 @@ from .nodes.base import (
 
 # Nodos individuales
 from .nodes.scene_instance import SceneInstanceNode
+from .nodes.alembic_import import AlembicImportNode
 from .nodes.transform import TransformNode
 from .nodes.group import GroupNode
 from .nodes.light import LightNode
@@ -55,7 +56,7 @@ classes = [
     BoolSocket,
     VectorSocket,
     StringSocket,
-    SceneInstanceNode, TransformNode, GroupNode,
+    SceneInstanceNode, AlembicImportNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
     JoinStringNode, SplitStringNode,
     ScenePropertiesNode, RenderPropertiesNode, OutputPropertiesNode,

--- a/documentation.txt
+++ b/documentation.txt
@@ -49,6 +49,16 @@ Crea una instancia de otro archivo `.blend`.
 - En modo `Instance` el nodo elimina instancias previas para evitar duplicados.
 - En modo `Link Override` se crea una biblioteca sobreescrita real en vez de un `Append`.
 
+### Alembic Import
+Importa un archivo `.abc` y lo coloca dentro de la escena.
+- **File Path**: ruta del archivo Alembic.
+- **Scale**: factor de escala aplicado a los objetos importados.
+- **Set Frame Range**: ajusta el rango de fotogramas a los del archivo.
+- **Validate Meshes**: comprueba la validez de las mallas al importar.
+- **Add Cache Reader**: añade modificadores de caché incluso si no hay animación.
+- **Is Sequence**: activa si el caché está dividido en varios archivos.
+- **Background Job**: ejecuta la importación en segundo plano.
+
 ### Transform
 Aplica transformaciones básicas.
 - **Translate**: desplazamiento (XYZ).

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,4 +1,5 @@
 from .scene_instance import SceneInstanceNode
+from .alembic_import import AlembicImportNode
 from .transform import TransformNode
 from .group import GroupNode
 from .light import LightNode
@@ -14,7 +15,7 @@ from .output_properties import OutputPropertiesNode
 from .cycles_attributes import CyclesAttributesNode
 
 __all__ = [
-    "SceneInstanceNode", "TransformNode", "GroupNode",
+    "SceneInstanceNode", "AlembicImportNode", "TransformNode", "GroupNode",
     "LightNode", "GlobalOptionsNode", "OutputsStubNode",
     "SceneOutputNode", "InputNode", "ScenePropertiesNode",
     "RenderPropertiesNode", "OutputPropertiesNode",

--- a/nodes/alembic_import.py
+++ b/nodes/alembic_import.py
@@ -1,0 +1,36 @@
+import bpy
+from .base import BaseNode, build_props_and_sockets
+
+
+class AlembicImportNode(BaseNode):
+    bl_idname = "AlembicImportNodeType"
+    bl_label = "Alembic Import"
+
+    def init(self, context):
+        self.add_enabled_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        pass  # Inputs already expose editable values next to their sockets
+
+
+build_props_and_sockets(
+    AlembicImportNode,
+    [
+        (
+            "file_path",
+            "string",
+            {"name": "File Path", "subtype": "FILE_PATH"},
+        ),
+        ("scale", "float", {"name": "Scale", "default": 1.0}),
+        ("set_frame_range", "bool", {"name": "Set Frame Range", "default": True}),
+        ("validate_meshes", "bool", {"name": "Validate Meshes", "default": False}),
+        (
+            "always_add_cache_reader",
+            "bool",
+            {"name": "Add Cache Reader", "default": False},
+        ),
+        ("is_sequence", "bool", {"name": "Is Sequence", "default": False}),
+        ("as_background_job", "bool", {"name": "Background Job", "default": False}),
+    ],
+)

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -9,6 +9,7 @@ class SceneNodeCategory(NodeCategory):
 node_categories = [
     SceneNodeCategory('SCENE_NODES', "Scene Nodes", items=[
         NodeItem("SceneInstanceNodeType"),
+        NodeItem("AlembicImportNodeType"),
         NodeItem("TransformNodeType"),
         NodeItem("InputNodeType"),
         NodeItem("JoinStringNodeType"),


### PR DESCRIPTION
## Summary
- support Alembic import to load `.abc` scenes
- register the new node in the add-on and UI
- document Alembic Import node

## Testing
- `pytest -q scene_nodes/tests/test_filters.py` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_684fb56c27a88330a04eebd6ed8999e1