### PR TITLE
Add RenderPasses node and evaluation context

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,6 +37,13 @@ from .nodes.split_string import SplitStringNode
 from .nodes.cycles_properties import CyclesPropertiesNode
 from .nodes.eevee_properties import EeveePropertiesNode
 from .nodes.cycles_attributes import CyclesAttributesNode
+from .nodes.render_passes import (
+    RenderPassesNode,
+    RenderPassItem,
+    SCENE_NODES_UL_render_passes,
+    SCENE_NODES_OT_render_pass_add,
+    SCENE_NODES_OT_render_pass_remove,
+)
 
 # UI
 from .ui.node_categories import node_categories
@@ -60,6 +67,9 @@ classes = [
     JoinStringNode, SplitStringNode,
     CyclesPropertiesNode, EeveePropertiesNode,
     CyclesAttributesNode,
+    RenderPassesNode, RenderPassItem,
+    SCENE_NODES_UL_render_passes,
+    SCENE_NODES_OT_render_pass_add, SCENE_NODES_OT_render_pass_remove,
     NODE_OT_sync_to_scene,
 ]
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -12,6 +12,13 @@ from .split_string import SplitStringNode
 from .cycles_properties import CyclesPropertiesNode
 from .eevee_properties import EeveePropertiesNode
 from .cycles_attributes import CyclesAttributesNode
+from .render_passes import (
+    RenderPassesNode,
+    RenderPassItem,
+    SCENE_NODES_UL_render_passes,
+    SCENE_NODES_OT_render_pass_add,
+    SCENE_NODES_OT_render_pass_remove,
+)
 
 __all__ = [
     "SceneInstanceNode", "AlembicImportNode", "TransformNode", "GroupNode",
@@ -19,4 +26,8 @@ __all__ = [
     "SceneOutputNode", "InputNode",
     "CyclesPropertiesNode", "EeveePropertiesNode",
     "CyclesAttributesNode", "JoinStringNode", "SplitStringNode",
+    "RenderPassesNode", "RenderPassItem",
+    "SCENE_NODES_UL_render_passes",
+    "SCENE_NODES_OT_render_pass_add",
+    "SCENE_NODES_OT_render_pass_remove",
 ]

--- a/nodes/render_passes.py
+++ b/nodes/render_passes.py
@@ -1,0 +1,62 @@
+import bpy
+from bpy.types import PropertyGroup, UIList, Operator
+from .base import BaseNode
+
+
+class RenderPassItem(PropertyGroup):
+    name: bpy.props.StringProperty(name="Name")
+
+
+class SCENE_NODES_UL_render_passes(UIList):
+    """UIList to display render passes."""
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.prop(item, "name", text="", emboss=False)
+
+
+class SCENE_NODES_OT_render_pass_add(Operator):
+    bl_idname = "scene_nodes.render_pass_add"
+    bl_label = "Add Render Pass"
+
+    def execute(self, context):
+        node = context.node
+        node.passes.add()
+        node.active_index = len(node.passes) - 1
+        return {'FINISHED'}
+
+
+class SCENE_NODES_OT_render_pass_remove(Operator):
+    bl_idname = "scene_nodes.render_pass_remove"
+    bl_label = "Remove Render Pass"
+
+    def execute(self, context):
+        node = context.node
+        if node.passes and 0 <= node.active_index < len(node.passes):
+            node.passes.remove(node.active_index)
+            node.active_index = min(node.active_index, len(node.passes) - 1)
+        return {'FINISHED'}
+
+
+class RenderPassesNode(BaseNode):
+    bl_idname = "RenderPassesNodeType"
+    bl_label = "Render Passes"
+
+    passes: bpy.props.CollectionProperty(type=RenderPassItem)
+    active_index: bpy.props.IntProperty()
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Scene")
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def draw_buttons(self, context, layout):
+        layout.template_list(
+            "SCENE_NODES_UL_render_passes",
+            "",
+            self,
+            "passes",
+            self,
+            "active_index",
+        )
+        row = layout.row(align=True)
+        row.operator('scene_nodes.render_pass_add', text='', icon='ADD')
+        row.operator('scene_nodes.render_pass_remove', text='', icon='REMOVE')

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -10,12 +10,22 @@ bpy.utils = types.SimpleNamespace(register_class=lambda *a, **k: None, unregiste
 bpy.data = types.SimpleNamespace()
 bpy.context = types.SimpleNamespace()
 bpy.types = types.ModuleType("bpy.types")
-bpy.props = types.SimpleNamespace(FloatProperty=lambda **k: None, IntProperty=lambda **k: None, BoolProperty=lambda **k: None, FloatVectorProperty=lambda **k: None, StringProperty=lambda **k: None, EnumProperty=lambda **k: None)
+bpy.props = types.SimpleNamespace(
+    FloatProperty=lambda **k: None,
+    IntProperty=lambda **k: None,
+    BoolProperty=lambda **k: None,
+    FloatVectorProperty=lambda **k: None,
+    StringProperty=lambda **k: None,
+    EnumProperty=lambda **k: None,
+    CollectionProperty=lambda **k: None,
+)
 bpy.types.NodeTree = type("NodeTree", (), {})
 bpy.types.Node = type("Node", (), {})
 bpy.types.NodeSocket = type("NodeSocket", (), {})
 bpy.types.Operator = type("Operator", (), {})
 bpy.types.Panel = type("Panel", (), {})
+bpy.types.PropertyGroup = type("PropertyGroup", (), {})
+bpy.types.UIList = type("UIList", (), {})
 sys.modules.setdefault("bpy", bpy)
 sys.modules.setdefault("bpy.types", bpy.types)
 mathutils = types.ModuleType("mathutils")

--- a/tests/test_properties_nodes.py
+++ b/tests/test_properties_nodes.py
@@ -12,12 +12,22 @@ bpy.context = types.SimpleNamespace(window=types.SimpleNamespace())
 bpy.utils = types.SimpleNamespace(register_class=lambda *a, **k: None,
                                   unregister_class=lambda *a, **k: None)
 bpy.types = types.ModuleType("bpy.types")
-bpy.props = types.SimpleNamespace(FloatProperty=lambda **k: None, IntProperty=lambda **k: None, BoolProperty=lambda **k: None, FloatVectorProperty=lambda **k: None, StringProperty=lambda **k: None, EnumProperty=lambda **k: None)
+bpy.props = types.SimpleNamespace(
+    FloatProperty=lambda **k: None,
+    IntProperty=lambda **k: None,
+    BoolProperty=lambda **k: None,
+    FloatVectorProperty=lambda **k: None,
+    StringProperty=lambda **k: None,
+    EnumProperty=lambda **k: None,
+    CollectionProperty=lambda **k: None,
+)
 bpy.types.NodeTree = type("NodeTree", (), {})
 bpy.types.Node = type("Node", (), {})
 bpy.types.NodeSocket = type("NodeSocket", (), {})
 bpy.types.Operator = type("Operator", (), {})
 bpy.types.Panel = type("Panel", (), {})
+bpy.types.PropertyGroup = type("PropertyGroup", (), {})
+bpy.types.UIList = type("UIList", (), {})
 sys.modules.setdefault("bpy", bpy)
 sys.modules.setdefault("bpy.types", bpy.types)
 
@@ -69,7 +79,8 @@ def test_cycles_properties():
         use_color_mode=True, color_mode="RGBA",
     )
     scene = FakeScene()
-    evaluator._evaluate_cycles_properties(node, [], scene)
+    ctx = types.SimpleNamespace(render_pass="")
+    evaluator._evaluate_cycles_properties(node, [], scene, ctx)
 
     assert scene.render.engine == "CYCLES"
     assert scene.render.resolution_x == 1280
@@ -100,7 +111,8 @@ def test_eevee_properties():
         use_color_mode=True, color_mode="RGB",
     )
     scene = FakeScene()
-    evaluator._evaluate_eevee_properties(node, [], scene)
+    ctx = types.SimpleNamespace(render_pass="")
+    evaluator._evaluate_eevee_properties(node, [], scene, ctx)
 
     assert scene.render.engine == "BLENDER_EEVEE"
     assert scene.render.resolution_x == 1024

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -18,6 +18,7 @@ node_categories = [
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),
         NodeItem("OutputsStubNodeType"),
+        NodeItem("RenderPassesNodeType"),
         NodeItem("CyclesPropertiesNodeType"),
         NodeItem("EeveePropertiesNodeType"),
         NodeItem("CyclesAttributesNodeType"),

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -16,6 +16,7 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"
         layout.operator("node.add_node", text="Render Outputs").type = "OutputsStubNodeType"
+        layout.operator("node.add_node", text="Render Passes").type = "RenderPassesNodeType"
         layout.operator("node.add_node", text="Scene Properties").type = "ScenePropertiesNodeType"
         layout.operator("node.add_node", text="Render Properties").type = "RenderPropertiesNodeType"
         layout.operator("node.add_node", text="Output Properties").type = "OutputPropertiesNodeType"


### PR DESCRIPTION
## Summary
- add RenderPasses node with UIList to manage passes
- register RenderPasses node in addon init, node categories and add menu
- extend evaluator to pass context with render pass info
- adjust tests for new context and bpy stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe0db32908330a07ac5e2b346b95b