### PR TITLE
Add NameSwitch node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,13 @@ from .nodes.scene_output import SceneOutputNode
 from .nodes.input import InputNode
 from .nodes.join_string import JoinStringNode
 from .nodes.split_string import SplitStringNode
+from .nodes.name_switch import (
+    NameSwitchNode,
+    NameSwitchItem,
+    SCENE_NODES_UL_name_switch,
+    SCENE_NODES_OT_name_switch_add,
+    SCENE_NODES_OT_name_switch_remove,
+)
 from .nodes.cycles_properties import CyclesPropertiesNode
 from .nodes.eevee_properties import EeveePropertiesNode
 from .nodes.cycles_attributes import CyclesAttributesNode
@@ -65,6 +72,9 @@ classes = [
     SceneInstanceNode, AlembicImportNode, TransformNode, GroupNode,
     LightNode, GlobalOptionsNode, OutputsStubNode, SceneOutputNode, InputNode,
     JoinStringNode, SplitStringNode,
+    NameSwitchNode, NameSwitchItem,
+    SCENE_NODES_UL_name_switch, SCENE_NODES_OT_name_switch_add,
+    SCENE_NODES_OT_name_switch_remove,
     CyclesPropertiesNode, EeveePropertiesNode,
     CyclesAttributesNode,
     RenderPassesNode, RenderPassItem,

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -512,6 +512,27 @@ def _evaluate_split_string(node, _inputs, _scene, context):
     return None
 
 
+def _evaluate_name_switch(node, _inputs, _scene, context):
+    target = getattr(context, "render_pass", "")
+    chosen = None
+    default = None
+    for sock in node.inputs:
+        if sock.bl_idname != "SceneSocketType" or not sock.is_linked:
+            continue
+        if not sock.links:
+            continue
+        scene_in = getattr(sock.links[0].from_node, "scene_nodes_output", None)
+        if sock.name == target:
+            chosen = scene_in
+            break
+        if sock.name == "Default" and default is None:
+            default = scene_in
+    if chosen is None:
+        chosen = default
+    node.scene_nodes_output = chosen
+    return chosen
+
+
 def _evaluate_input(node, _inputs, _scene, context):
     node.scene_nodes_output = None
     return None
@@ -553,6 +574,8 @@ def _evaluate_node(node, scene, context):
         return _evaluate_join_string(node, inputs, scene, context)
     elif ntype == "SplitStringNodeType":
         return _evaluate_split_string(node, inputs, scene, context)
+    elif ntype == "NameSwitchNodeType":
+        return _evaluate_name_switch(node, inputs, scene, context)
     else:
         print(f"[scene_nodes] unknown node type {ntype}")
 

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -9,6 +9,13 @@ from .scene_output import SceneOutputNode
 from .input import InputNode
 from .join_string import JoinStringNode
 from .split_string import SplitStringNode
+from .name_switch import (
+    NameSwitchNode,
+    NameSwitchItem,
+    SCENE_NODES_UL_name_switch,
+    SCENE_NODES_OT_name_switch_add,
+    SCENE_NODES_OT_name_switch_remove,
+)
 from .cycles_properties import CyclesPropertiesNode
 from .eevee_properties import EeveePropertiesNode
 from .cycles_attributes import CyclesAttributesNode
@@ -26,6 +33,9 @@ __all__ = [
     "SceneOutputNode", "InputNode",
     "CyclesPropertiesNode", "EeveePropertiesNode",
     "CyclesAttributesNode", "JoinStringNode", "SplitStringNode",
+    "NameSwitchNode", "NameSwitchItem",
+    "SCENE_NODES_UL_name_switch", "SCENE_NODES_OT_name_switch_add",
+    "SCENE_NODES_OT_name_switch_remove",
     "RenderPassesNode", "RenderPassItem",
     "SCENE_NODES_UL_render_passes",
     "SCENE_NODES_OT_render_pass_add",

--- a/nodes/name_switch.py
+++ b/nodes/name_switch.py
@@ -1,0 +1,83 @@
+import bpy
+from bpy.types import PropertyGroup, UIList, Operator
+from .base import BaseNode
+
+
+class NameSwitchItem(PropertyGroup):
+    name: bpy.props.StringProperty(
+        name="Name",
+        update=lambda self, ctx: getattr(self.id_data, "update_sockets", lambda: None)(),
+    )
+
+
+class SCENE_NODES_UL_name_switch(UIList):
+    """UIList to display switch inputs."""
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.prop(item, "name", text="", emboss=False)
+
+
+class SCENE_NODES_OT_name_switch_add(Operator):
+    bl_idname = "scene_nodes.name_switch_add"
+    bl_label = "Add Input"
+
+    def execute(self, context):
+        node = context.node
+        node.names.add()
+        node.active_index = len(node.names) - 1
+        node.update_sockets()
+        return {'FINISHED'}
+
+
+class SCENE_NODES_OT_name_switch_remove(Operator):
+    bl_idname = "scene_nodes.name_switch_remove"
+    bl_label = "Remove Input"
+
+    def execute(self, context):
+        node = context.node
+        if node.names and 0 <= node.active_index < len(node.names):
+            node.names.remove(node.active_index)
+            node.active_index = min(node.active_index, len(node.names) - 1)
+            node.update_sockets()
+        return {'FINISHED'}
+
+
+class NameSwitchNode(BaseNode):
+    bl_idname = "NameSwitchNodeType"
+    bl_label = "Name Switch"
+
+    names: bpy.props.CollectionProperty(type=NameSwitchItem)
+    active_index: bpy.props.IntProperty()
+
+    def init(self, context):
+        self.inputs.new('SceneSocketType', "Default")
+        self.update_sockets()
+        self.outputs.new('SceneSocketType', "Scene")
+
+    def update_sockets(self):
+        existing = {
+            sock.name: sock
+            for sock in self.inputs
+            if sock.bl_idname == 'SceneSocketType' and sock.name != 'Default'
+        }
+        for item in self.names:
+            if item.name in existing:
+                existing.pop(item.name)
+            else:
+                self.inputs.new('SceneSocketType', item.name)
+        for sock in existing.values():
+            self.inputs.remove(sock)
+
+    def draw_buttons(self, context, layout):
+        layout.template_list(
+            "SCENE_NODES_UL_name_switch",
+            "",
+            self,
+            "names",
+            self,
+            "active_index",
+        )
+        row = layout.row(align=True)
+        row.operator('scene_nodes.name_switch_add', text='', icon='ADD')
+        row.operator('scene_nodes.name_switch_remove', text='', icon='REMOVE')
+

--- a/tests/test_name_switch.py
+++ b/tests/test_name_switch.py
@@ -1,0 +1,59 @@
+import types
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Stub Blender modules
+bpy = types.ModuleType("bpy")
+bpy.__path__ = []
+bpy.utils = types.SimpleNamespace(register_class=lambda *a, **k: None, unregister_class=lambda *a, **k: None)
+bpy.data = types.SimpleNamespace()
+bpy.context = types.SimpleNamespace()
+bpy.types = types.ModuleType("bpy.types")
+bpy.props = types.SimpleNamespace(
+    FloatProperty=lambda **k: None,
+    IntProperty=lambda **k: None,
+    BoolProperty=lambda **k: None,
+    FloatVectorProperty=lambda **k: None,
+    StringProperty=lambda **k: None,
+    EnumProperty=lambda **k: None,
+    CollectionProperty=lambda **k: None,
+)
+bpy.types.NodeTree = type("NodeTree", (), {})
+bpy.types.Node = type("Node", (), {})
+bpy.types.NodeSocket = type("NodeSocket", (), {})
+bpy.types.Operator = type("Operator", (), {})
+bpy.types.Panel = type("Panel", (), {})
+bpy.types.PropertyGroup = type("PropertyGroup", (), {})
+bpy.types.UIList = type("UIList", (), {})
+sys.modules.setdefault("bpy", bpy)
+sys.modules.setdefault("bpy.types", bpy.types)
+
+from scene_nodes.engine import evaluator
+
+
+def make_socket(name, from_node):
+    return types.SimpleNamespace(
+        bl_idname="SceneSocketType",
+        name=name,
+        is_linked=True,
+        links=[types.SimpleNamespace(from_node=from_node)],
+    )
+
+
+def test_name_switch():
+    node_a = types.SimpleNamespace(scene_nodes_output="A")
+    node_b = types.SimpleNamespace(scene_nodes_output="B")
+    socket_a = make_socket("PassA", node_a)
+    socket_default = make_socket("Default", node_b)
+    node = types.SimpleNamespace(inputs=[socket_a, socket_default])
+    ctx = types.SimpleNamespace(render_pass="PassA")
+
+    result = evaluator._evaluate_name_switch(node, [], None, ctx)
+    assert result == "A"
+
+    ctx.render_pass = "Other"
+    result = evaluator._evaluate_name_switch(node, [], None, ctx)
+    assert result == "B"
+

--- a/ui/node_categories.py
+++ b/ui/node_categories.py
@@ -14,6 +14,7 @@ node_categories = [
         NodeItem("InputNodeType"),
         NodeItem("JoinStringNodeType"),
         NodeItem("SplitStringNodeType"),
+        NodeItem("NameSwitchNodeType"),
         NodeItem("GroupNodeType"),
         NodeItem("LightNodeType"),
         NodeItem("GlobalOptionsNodeType"),

--- a/ui/node_editor.py
+++ b/ui/node_editor.py
@@ -12,6 +12,7 @@ class SCENE_GRAPH_MT_add(Menu):
         layout.operator("node.add_node", text="Input").type = "InputNodeType"
         layout.operator("node.add_node", text="Join String").type = "JoinStringNodeType"
         layout.operator("node.add_node", text="Split String").type = "SplitStringNodeType"
+        layout.operator("node.add_node", text="Name Switch").type = "NameSwitchNodeType"
         layout.operator("node.add_node", text="Group").type = "GroupNodeType"
         layout.operator("node.add_node", text="Light").type = "LightNodeType"
         layout.operator("node.add_node", text="Global Options").type = "GlobalOptionsNodeType"


### PR DESCRIPTION
## Summary
- add NameSwitch node for selecting a scene input by render pass name
- register NameSwitch node and expose it in menus and categories
- evaluate NameSwitch during tree evaluation
- test NameSwitch evaluation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe7e12878833080f20e2636413caa