### PR TITLE
Implement render pass wedge operator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -54,7 +54,7 @@ from .nodes.render_passes import (
 
 # UI
 from .ui.node_categories import node_categories
-from .ui.operators import NODE_OT_sync_to_scene
+from .ui.operators import NODE_OT_sync_to_scene, RENDER_OT_render_pass_wedge
 from . import ui
 
 # Engine
@@ -80,7 +80,7 @@ classes = [
     RenderPassesNode, RenderPassItem,
     SCENE_NODES_UL_render_passes,
     SCENE_NODES_OT_render_pass_add, SCENE_NODES_OT_render_pass_remove,
-    NODE_OT_sync_to_scene,
+    NODE_OT_sync_to_scene, RENDER_OT_render_pass_wedge,
 ]
 
 NODETREE_CATEGORY = 'SCENE_NODES'

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,5 +1,5 @@
 # ui/__init__.py
-from .operators import NODE_OT_sync_to_scene
+from .operators import NODE_OT_sync_to_scene, RENDER_OT_render_pass_wedge
 from .node_panel import (
     SCENE_NODES_PT_node_props,
     SCENE_NODES_PT_node_props_properties,
@@ -8,6 +8,7 @@ from .node_panel import (
 
 __all__ = [
     "NODE_OT_sync_to_scene",
+    "RENDER_OT_render_pass_wedge",
     "SCENE_NODES_PT_node_props",
     "SCENE_NODES_PT_node_props_properties",
     "SCENE_NODES_PT_socket_visibility",

--- a/ui/operators.py
+++ b/ui/operators.py
@@ -27,3 +27,52 @@ class NODE_OT_sync_to_scene(bpy.types.Operator):
 
         evaluate_scene_tree(tree)
         return {'FINISHED'}
+
+
+class RENDER_OT_render_pass_wedge(bpy.types.Operator):
+    bl_idname = "scene_nodes.render_pass_wedge"
+    bl_label = "Render Pass Wedge"
+    bl_description = "Render all passes defined in the Render Passes node"
+
+    def execute(self, context):
+        from ..engine.evaluator import evaluate_scene_tree
+
+        tree = None
+
+        if context.area and context.area.type == 'NODE_EDITOR':
+            space = context.space_data
+            if space and space.tree_type == 'SceneNodeTreeType':
+                tree = space.node_tree
+
+        if tree is None:
+            for nt in bpy.data.node_groups:
+                if nt.bl_idname == 'SceneNodeTreeType':
+                    tree = nt
+                    break
+
+        if tree is None:
+            self.report({'ERROR'}, "No Scene Node Tree found")
+            return {'CANCELLED'}
+
+        passes_node = None
+        for node in tree.nodes:
+            if node.bl_idname == 'RenderPassesNodeType':
+                passes_node = node
+                break
+
+        if passes_node is None or not passes_node.passes:
+            self.report({'ERROR'}, "No Render Passes node found")
+            return {'CANCELLED'}
+
+        for item in passes_node.passes:
+            # Ensure a view layer exists for this pass
+            layer = context.scene.view_layers.get(item.name)
+            if layer is None:
+                layer = context.scene.view_layers.new(name=item.name)
+            context.window.view_layer = layer
+
+            setattr(context, "render_pass", item.name)
+            evaluate_scene_tree(tree)
+            bpy.ops.render.render(write_still=True)
+
+        return {'FINISHED'}


### PR DESCRIPTION
## Summary
- add `RENDER_OT_render_pass_wedge` to render all passes of `RenderPassesNode`
- expose new operator via addon registration
- export operator through `ui.__init__`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff4510d108330a367562da8bdcf93