### PR TITLE
Update docs for Render node

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 The tree can be evaluated via the **Sync to Scene** operator (accessible with **F3**) or from a Python script.
 The operator uses the Scene Graph tree currently open in the Node Editor (or the
 first one it finds in the file) so scenes don't need their own tree pointer.
+Each **Render** node in the tree produces an output image during evaluation.
 
 ## Quick Example
 
@@ -41,12 +42,15 @@ from scene_nodes.engine import evaluate_scene_tree
 # Create a Scene Node Tree
 tree = bpy.data.node_groups.new("Example", "SceneNodeTreeType")
 
+
 # Add nodes
 inst = tree.nodes.new("SceneInstanceNodeType")
-out = tree.nodes.new("EeveePropertiesNodeType")
+props = tree.nodes.new("EeveePropertiesNodeType")
+render = tree.nodes.new("RenderNodeType")
 
-# Link instance to output
-tree.links.new(inst.outputs[0], out.inputs[0])
+# Link instance to properties and then to render
+tree.links.new(inst.outputs[0], props.inputs[0])
+tree.links.new(props.outputs[0], render.inputs[0])
 
 # Evaluate the tree (applies changes to the scene)
 evaluate_scene_tree(tree)

--- a/documentation.txt
+++ b/documentation.txt
@@ -25,7 +25,8 @@ Uso básico
 2. Añade nodos desde el menú **Add > Scene Node**.
 3. Conecta las salidas y entradas de tipo `Scene` entre nodos.
 4. Ejecuta el operador **Sync to Scene** (menú F3) para evaluar el árbol y
-   sincronizarlo con la escena de Blender.
+   sincronizarlo con la escena de Blender. Cada nodo **Render** producirá
+   una imagen de salida.
    El operador utiliza el árbol de Scene Graph activo en el Node Editor (o el
    primero que encuentre en el archivo), por lo que las escenas no necesitan
    tener un árbol asignado.
@@ -117,9 +118,12 @@ Ajusta atributos específicos de Cycles para los objetos.
 - **Visible Camera/Diffuse/Glossy/Transmission/Volume/Shadow**: controlar la visibilidad de rayos.
 - **Filter**: patrón opcional para aplicar los cambios solo a los objetos que coincidan.
 
-### Scene Output
-Define el nombre de la escena resultante. Debe situarse al final del
-árbol y es obligatorio para ejecutar la evaluación.
+### Render
+Ejecuta el render final y define la salida.
+- **Name**: nombre de la pasada de render.
+- **File Path**: ruta de la imagen resultante.
+- **Format**: formato de archivo (OpenEXR o PNG).
+Debe colocarse al final del árbol y es necesario para evaluar la escena.
 
 Conexión de propiedades
 -----------------------
@@ -142,8 +146,8 @@ Flujo de trabajo recomendado
 2. Añade instancias o grupos según sea necesario.
 3. Inserta nodos **Transform** para posicionar los elementos.
 4. Utiliza **Light** para iluminar.
-5. Cierra el árbol con **Scene Output** para crear la escena.
-6. Ejecuta **Sync to Scene** para aplicar los cambios.
+5. Finaliza con un nodo **Render** para generar la imagen.
+6. Ejecuta **Sync to Scene** para aplicar y renderizar los cambios.
 Ten en cuenta que este complemento sigue siendo experimental, pero ahora la
 evaluación del árbol aplica los cambios directamente en la escena de Blender en
 lugar de limitarse a imprimir información en la consola. Sirve como base para


### PR DESCRIPTION
## Summary
- document new **Render** node
- update workflow steps and usage notes
- update Quick Example to use Render node
- remove references to deprecated Scene Output node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510422aadc83308908e7deb7d0c449