### PR TITLE
Add Markdown to PDF conversion script

### DIFF
--- a/documentation.pdf
+++ b/documentation.pdf
@@ -1,0 +1,214 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 29 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 28 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 30 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 28 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Outlines 10 0 R /PageMode /UseNone /Pages 28 0 R /Type /Catalog
+>>
+endobj
+9 0 obj
+<<
+/Author () /CreationDate (D:20250617064447+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250617064447+00'00') /Producer (xhtml2pdf <https://github.com/xhtml2pdf/xhtml2pdf/>) 
+  /Subject () /Title () /Trapped /False
+>>
+endobj
+10 0 obj
+<<
+/Count 3 /First 11 0 R /Last 11 0 R /Type /Outlines
+>>
+endobj
+11 0 obj
+<<
+/Count -5 /Dest [ 6 0 R /Fit ] /First 12 0 R /Last 27 0 R /Parent 10 0 R /Title (Scene Nodes - Documentaci\363n para Usuarios)
+>>
+endobj
+12 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 13 0 R /Parent 11 0 R /Title (Instalaci\363n)
+>>
+endobj
+13 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 14 0 R /Parent 11 0 R /Prev 12 0 R /Title (Uso b\341sico)
+>>
+endobj
+14 0 obj
+<<
+/Count -11 /Dest [ 6 0 R /Fit ] /First 15 0 R /Last 25 0 R /Next 26 0 R /Parent 11 0 R 
+  /Prev 13 0 R /Title (Nodos disponibles)
+>>
+endobj
+15 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 16 0 R /Parent 14 0 R /Title (Scene Instance)
+>>
+endobj
+16 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 17 0 R /Parent 14 0 R /Prev 15 0 R /Title (Alembic Import)
+>>
+endobj
+17 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 18 0 R /Parent 14 0 R /Prev 16 0 R /Title (Transform)
+>>
+endobj
+18 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 19 0 R /Parent 14 0 R /Prev 17 0 R /Title (Group)
+>>
+endobj
+19 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 20 0 R /Parent 14 0 R /Prev 18 0 R /Title (Light)
+>>
+endobj
+20 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 21 0 R /Parent 14 0 R /Prev 19 0 R /Title (Join String)
+>>
+endobj
+21 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 22 0 R /Parent 14 0 R /Prev 20 0 R /Title (Split String)
+>>
+endobj
+22 0 obj
+<<
+/Dest [ 6 0 R /Fit ] /Next 23 0 R /Parent 14 0 R /Prev 21 0 R /Title (Cycles Properties)
+>>
+endobj
+23 0 obj
+<<
+/Dest [ 7 0 R /Fit ] /Next 24 0 R /Parent 14 0 R /Prev 22 0 R /Title (Eevee Properties)
+>>
+endobj
+24 0 obj
+<<
+/Dest [ 7 0 R /Fit ] /Next 25 0 R /Parent 14 0 R /Prev 23 0 R /Title (Cycles Attributes)
+>>
+endobj
+25 0 obj
+<<
+/Dest [ 7 0 R /Fit ] /Parent 14 0 R /Prev 24 0 R /Title (Render)
+>>
+endobj
+26 0 obj
+<<
+/Dest [ 7 0 R /Fit ] /Next 27 0 R /Parent 11 0 R /Prev 14 0 R /Title (Conexi\363n de propiedades)
+>>
+endobj
+27 0 obj
+<<
+/Dest [ 7 0 R /Fit ] /Parent 11 0 R /Prev 26 0 R /Title (Actualizaci\363n)
+>>
+endobj
+28 0 obj
+<<
+/Count 2 /Kids [ 6 0 R 7 0 R ] /Type /Pages
+>>
+endobj
+29 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2892
+>>
+stream
+Gb!#^D0+Gi')q<+Z-uM>9u;^)U>uiUE?%&7`bh8K]t*HBV?9]"N0FHIOAm_0qV)0%>)kk9NGZqZ@uE'-@,L^(QM+aC?bZ?(joB=tnE.Rm5Chu-plQB/oFfHI7t2P-_Jd1l*K7Zc)FYlA-F#KI"[5,^Fk_]'c#:6d&rqT!Hp,?+rUqdlkkRM($t5TW++*P1%q7T`bsanl_Jp4;q;-(Ds,rpK]nF4EasDgMe:O%V)W%I#cFL#Y.V@WfPYa'Yi4$"(>,_!/VI*a-0@JmEdGn/\2C%)u-@!q79em,Kd]ZkV&+uB9^)n;rHuGdC%uFrK)4E2krk,<lUae#Q:/WTEE-Rjl\_nCUNTM[F>!aZW=jDQt?#VBSH5Xq0aVG5n"K<0:[#/m,Z@&5u%D5*@YgS0'AgI^ci\O8@$7ah:cbdaV@3Nc[8MSQ8.C/(d]IaJR@UlCR&(\J`2(NQo^`0T-F?]lA&=(ZhYW:V,D;.&>i[ro6`UAjXeg-mF+%^O96QD+@*.e=nPJMD)AjPEFP;)?Fe9D\J;=^i9-=5V+`f5U;D]G0)ZXJX`_Vih?qd9le6s4HaLTrf1LZ:",*se9rn0Hsnj@i+e2LIQ(%".@NPfFZ72CR;^p;cAY$mhd;$l#M*Or.^D[$hf2U^.O3\*HNthb-ED:d91op!<5]rDiHH6,im6;:)/mrlmmA=[&Kpj*sV"6I!2eWr_<1jqlM2XhYABrPKAo"q'Y$h'Zsh^/JBMVV$K$3B)7;Wh8SPm'sgX'252h`*E)-7[Is0>]FHE'XX_sa6Eak_Nj7B>]Z<Bnc'1r(Q6m;3ZPAYU<ZBO2E$ONcgu<$l>PTXlii0#lKB)pI*FI=VS]-MAjVZ!RKWRuX!RGJ!uCT_'Y!iTmI1dYMbI*1d+H2Mc9t&fA_<=eF[0O@n%29T?4cs[A#]WSoMkZD"-uts7<m`*'P`7*;U#e6d']IG$r^oih!)ZUK+9CLFKfO,1`\dT"KX9qN]]OoFQ9TlC@Ap&$Kf>V,#s&fNQ7_ORO"F@q#@Y3T?aia&Ht4c><f6pcfK4V.RA[lZ$TnM\17$_#jC[>3#R$>F9'cQ-SdYMm,t^W*,2,fbN:?LJmD;`J&3g\?W`n-Y;l(M6\O072YAjPH"q:t#pmd5!^G:%N.TI=2`2q0(h'Qc>j6`A:u]:Z+(l`0ct@4HO3g@3^&(_MJOj-m>$!%@(",G0K%c?WCRG7Papo*1#+J`.#\V0eKj:ma-3BUCSH-?&$CPYiMKaeBVTSNqb;$IcWs=uY#W<]HAGL&-lj3+gpI8af'N\a"dV;XW_DEN)c)`4c,%jPb]6K^&*=pH)1p8EGj*0j@e@9V$38'U1#kL":NkdXRWZZ&9j;,Qq/kTmu?Zp^Ih.OdX/i@0_'a8WqZVfsf;N,XVe;-]Ug5',KqmS>c;Cj+dr*9p#?8*Aem5e$q$<([BZS4j]+<DZJ8(3'l(pSK4`t$E@d_`&-Fc4(e!HQUi_e:mpWBg3^,oHsF.MM5"F/)`QU`.nLgh(CEQV5`eaQBqPdFm'&?WkW(reGn9,K)cT*:LCo)(+^hEP(X9K1(M?r4!^D]bKc-`V-Q[.b&fO(1E=$iLVdJe)2^0;^Gu1%eWFhh)<em:-cHD3EW&^>0n!"XLb3:;@(!E1`FRi`7;qU<YVP3HU]t4HfOW[jl/k!lmRXMLJ_Hd$Tu2s`7X\Y9f*;:7:P"UbW,<N]mT<_6M51]B?1mf7U,"';dk!'U']djfWioL]fEKX?/u*kG<<fu^fkfuWa0"X!kL;>X"DTA%F.q-1q,f?gU0bU$kKdT[5HdqaM4R@FrkWp_j[3'@.%Q,q9u'W.K=/Cj6a5br;X!0md,9LjIa'?h-k_8#f!OPf"qST;8I;[3@<5CURgsP(SL]D:Q^S&BV5dp/+[J;"ZAe[JT[*3PS%`dGM[dGW<<c<D4</3i>dcA:_cbDPR;\q.1mCD\1XOG^>a>NT\,>&HDZ1S#Qnm0#:pLc)9:$m_MA"0eO.P'8\EGW1%uE>NcGa-e?0iG(KOMD4U^'t%r@iKk'%#OAh%Bd8U?F_T3OLOZ)2T;l]bt`m(PbNBnmT`+@fjB'A$>CW$eS?(LBs?Z>)>g^:QOH]f3IJ/EcMjaee;gp8'Ani7GKUR,CG6C5EI0MV1?=X,-d6fGT7ocb-o59X[^?kYKfXDW]b*>&L[$^i%FQqS6o^P]GADiji\Q]gYp\F('OIV;]_%l<"2-NA7'6K;TDB+Q-tGHDu]I8-QJ=%87r`BSs5sJ.Er2F%#5pEcogS^'sDMmZ6=<71]LYcUoaAIC$@;D[eW0Fo1VZ9E/73<QbPn<--*"]HM%C2O?/Lg[lL]Lh;K*-n$htqicX4H[`?2k<F%<R:>6B2bN8H,n)#:fW3qX(G[fb#Lu9n7MBVIT?ZS[\QrgSa=muAhEn<"5.G+50^iLaKE(lDpXufmS'S*Tn"J:FDp8LI@H=CYOa,Qa=]^l&C<K),hKDE,N=QmEmkG!'^=)h@TbkCE<*XF6$i=7YNd*s]1a]6:2/-ep([H8&?uTq]d+$<bTslXF?\:^LqGJk_HT-=:)EgDnSmprM!+bb.o1igl8"Qjk=+kK=bd>E,E2A5h?GUb9nOK;Bne;W!8=FVAolBHP'-H9S5*?fR](ghsFXMbZHL'8@ed`mBFN@SZLt71D8di2r/`SPWJsVB$,uZ@P1_msK=n065!S&KkhGt<-,*"oraGh1@.c@pDC;t>e$@^A;@*R/Oj([7TpHJQ$b3"@-7M/8t3Ph;!prr:hlT[oWqhCd4)0A%9+9C5,oaeqbSf!(K6K?"."Ki.8ZPKBgY5R+O$JRI"M2'F?Y9ce9S8j%K\2)\2(Hl><>fY<*n&h'pmCA^K14_2iYF44QCg^mo@[J!cFuZClX]'OgH_kF7?AX[c*ZY+hUmTuu~>endstream
+endobj
+30 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2574
+>>
+stream
+Gb"/(;01JM&q9SY_">a^EG:Q".&hVe;CCj+/ob@.e'@^l+s@gf&n"8WZ1@5X/O30r"j(l4l.jP6*a97K//F.^^\noTf`8d\rLXja]puA!f-(MH2I!D)(_#*a/\@C@Hoh(R^T`,IRKW.7)('0i,f+.2`u)F24(R6&mRf/S`*kK3T-&?6BuA5[@2L9KLs68BL&l20"7g.GN6%uLrN2CPoT_&k;K8SW<,*^oQ3eo'<%*48.\SUpYna<b/i1dF??,[RQ0+eNfQZ[d2S4[jBPmD6USr=l(t`93Sc@R'mcHY1*X:k[<*mU:XCrq>K@ecAMALkM).&a&$^LOhEOF;,-#Im-l.Ys"F2jIrGWQ:LgS(s'lrq0:nlT.1UR.@7_j7H-/XDC=[+Dumn.)d1Ec^8^XYFdI2$e#E*=p&>4;7Ip2F88a=>>po?DTUOc>W]>(F?rb0s.V=EJ1mib)8a=VW.!k@Im#Ts2FH[9AQPrB6G;jduF0T*5@hoFrN<j`h<J8cC6Kd4d3E9'U"\^V*J#PHJN*^KDSRB6h"8\"ZP:DU)S8<p3DL&?D"qbKt@'H,HP7dHZT.fJ'2r:/!%A1B+@CQhlX*jLRTDgImt'#YY"cO5Um;"5r:`jb+iZ5hFglXO,&ilegLgYA;tOg,Su)!JtMSi/#D]g\.]-nV+XZ'g$WYe8!D%O#`h%Cho%NuQ%)`XruU98]/),3`fkUPNns38bU&uYF<K("IqjY-8`.WV_YXH5nGc6A+G!pH<&ZoqfsoJV?5QV_H"3G]2GkG&r\WBrGTRHJ39e7605d8J'#M2:9GM\!O;Ob?6DiI7::hL4_RQE)[fT?O\+:u(!?WoA4dudhn^PWA5T!aF-gLutojuAQD=/FdPH,Xol-J]22sH<G![KQE9iddJJ5;k#gf,I4V/^IS_6(dRruuQVl,JL!0ISsZE!H*-lH8n$pK(M@3E"5OdeSrEZ"RllrW]'t=6DA9AR3Bg"p(7o$48E(\Qbpa?*uGQcF`R;,(tnf=O:ZBI!&h85Qo(G[1^+?G/.)rT"E80AM,F%[-9#0/]'$<"NY$k#E3=EeP`5_jU#'M(^-&;1+Th1fu(L#1's[&2B+`<L(FiCMYtGq8?!kWaCblP40ZT!ignV^Y/YfIoc6lj.n'SZdE9h!f,PF^OeR<#9\>fuCpi=6\^9DlWrnaX;^U4UdfJ'!0<Q4U]+P)\eejRZ_9!6?.c/]\,>r/"1S=rf?&#MfZD%D7`#432_C:PsECtWqc/(u.`^,t[iB\__P0mr&I^oF,+:>$1('-._4rJQX`P"5L4^(=Jq<g1nXFth`!nlGFSr<m&?l2V%Y7BR$TRf1b8rYl/B[T$]PnIYR6>?:(Ld4d<63U]S7)d;gB<BX4$ff1-U6,HPAL"EQi]E9ci5*E:mVu%NA&,MuR:<`6/7lXA?B)<#%9hRsJ*S11-)(9@;]T8!b4ukKHq)#p*&AM@`8/Vmdb4gp2nSX5]qcZ#o1J;N53rc4Q_IB.B*S#uV8*g,]:mqRf,K[daWsEsI<K^F+3+N4*b$7IWpTp\]FGf++U#=?fH*/I2_1s0;++80FmhZG.L9]fo<>0L,tV`bF&S#/gm5s%a$APaOfnS:hE`*@St$#bTrbhI?sK&a:CSJ^"*!)(#O2^>m#k1gC&&Nl/&l;V5hhf1QG*pVQM00LK])u'!jFA0V]tI25%#2LecAId&\='N7d4a(NW?"0[L(<g"YEgNIs<qag4M;1a!/'anlk09>,-"b5pV%)pr6df8OFV;UD"Z!XMY7%"bJ22b,F'g__i\q]QoU_G,WDqd>6<c+dHeVgV$>D,3hmlS0_$,kP?+c<,FBn&c39N08*!,qo2hZJq1P[Rp0+<&>(ttFWqA-K;!F+AB&:W[ZL;&J,_WN0`(S,7+jL&)o\"K1l96IOL)!?`kiu,O)T`D&[ljq8oX2PI.5-ikV<[,o4Ej&N1Q8T;4sk9Z('4jc@1]8qN#-bnrSt-`+P^&0^h=\S'#G[GIl4p=9d0up3j?)8'`%B(R>*#:KO1kW-0G\B$72'\!a`AS>#^%&Q./+#:,m7O-Z\V$V:2S!VomKJ-\@B5MMloDEWLmKM>YHFu9_F:5j`FXEW%2ajK\OCdB"(A'f[E8nU@nDrpP%?hq<18[PtRmoBD7,k55/Bqo;L%>kc=cloMrpJKV]7b<-[0tpDtFg:\2eU!9P]'cJGoV->T?u;.QT*Sf`$/Zt2b/LTgSm$?[qaWt'PsVRY.hK0[_!IS$XP3[*T&=GLc[a8n4afpAA1k?#`)_3L-JEQrP$$^a%HTm8juo`%U`2E\F%V)BB\-o)k_b+5:=A`.LV)tVSO5IOGXlQU[4+S@0OEo0A:UgA9C>sqVk^4A#.@-K,H9.r%JJA(Rd4'jW)-AbeX^YRf::I0"_Z5ML/-qK,\O^6noROV!2Ver^O8p9r6>&>fR+M*"JXYfU]1AEds*i4I-C./>4!-*ff=rV]:rt$-(cMkV]C-=[:4KeJ!91Ypu$Ql?QAEJRkmj7:kB\96_6#mM2mIlec)NAN@>ffF;2N7_eoEL?Z8k/GoE(l]$E20UUmWf>bc:0j>;.n3+jUg!&9D8_u~>endstream
+endobj
+xref
+0 31
+0000000000 65535 f 
+0000000073 00000 n 
+0000000134 00000 n 
+0000000241 00000 n 
+0000000353 00000 n 
+0000000458 00000 n 
+0000000573 00000 n 
+0000000778 00000 n 
+0000000983 00000 n 
+0000001069 00000 n 
+0000001321 00000 n 
+0000001395 00000 n 
+0000001544 00000 n 
+0000001639 00000 n 
+0000001746 00000 n 
+0000001898 00000 n 
+0000001993 00000 n 
+0000002101 00000 n 
+0000002204 00000 n 
+0000002303 00000 n 
+0000002402 00000 n 
+0000002507 00000 n 
+0000002613 00000 n 
+0000002724 00000 n 
+0000002834 00000 n 
+0000002945 00000 n 
+0000003032 00000 n 
+0000003152 00000 n 
+0000003249 00000 n 
+0000003315 00000 n 
+0000006299 00000 n 
+trailer
+<<
+/ID 
+[<fe79b973f67604e5780edcb39fed3dc0><fe79b973f67604e5780edcb39fed3dc0>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 9 0 R
+/Root 8 0 R
+/Size 31
+>>
+startxref
+8965
+%%EOF

--- a/scripts/convert_doc_to_pdf.py
+++ b/scripts/convert_doc_to_pdf.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import markdown
+from xhtml2pdf import pisa
+
+
+def convert_markdown_to_pdf(md_path: str, pdf_path: str) -> None:
+    """Convert a Markdown file to a grayscale PDF."""
+    text = Path(md_path).read_text(encoding="utf-8")
+    html_body = markdown.markdown(text, extensions=["extra"])
+    css = """
+    <style>
+    body { font-family: Helvetica, Arial, sans-serif; color: #000; }
+    h1, h2, h3, h4, h5, h6 { color: #111; }
+    </style>
+    """
+    html = f"<html><head>{css}</head><body>{html_body}</body></html>"
+    with open(pdf_path, "wb") as target:
+        pisa.CreatePDF(html, dest=target)
+
+
+def main(args: list[str]) -> None:
+    if len(args) != 2:
+        print("Usage: convert_doc_to_pdf.py input.md output.pdf")
+        raise SystemExit(1)
+    convert_markdown_to_pdf(args[0], args[1])
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- add Python script to convert documentation into PDF
- generate `documentation.pdf` using the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510e8a6f688330a8f5453e048cd652