### PR TITLE
Implement Filter option for Scene Instance node

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ tree.links.new(props.outputs[0], render.inputs[0])
 evaluate_scene_tree(tree)
 ```
 
-Nodes that modify objects, such as **Transform** and **Cycles Attributes**, support
-an optional *Filter* property. The expression can include wildcards to match
-object names or collection paths, allowing selective updates.
+Nodes that modify or load objects, such as **Transform**, **Cycles Attributes**
+and **Scene Instance**, support an optional *Filter* property. The expression can
+include wildcards to match object names or collection paths, allowing selective
+updates.
 
 ## Migration
 

--- a/documentation.txt
+++ b/documentation.txt
@@ -49,6 +49,7 @@ Crea una instancia de otro archivo `.blend`.
 - **Load Mode**: `Append`, `Instance`, `Link` o `Link Override`.
 - En modo `Instance` el nodo elimina instancias previas para evitar duplicados.
 - En modo `Link Override` se crea una biblioteca sobreescrita real en vez de un `Append`.
+- **Filter**: permite cargar solo los objetos que coincidan con el patrón.
 
 ### Alembic Import
 Importa un archivo `.abc` y lo coloca dentro de la escena.
@@ -132,8 +133,8 @@ Puedes conectar estos sockets entre distintos nodos para compartir el mismo
 valor. Si un socket está enlazado, el nodo tomará el valor de la conexión;
 de lo contrario utilizará el valor interno editable en el propio nodo.
 
-Algunos nodos que modifican objetos incluyen un campo **Filter** para limitar
-los cambios según un patrón de nombre o ruta de colección.
+Algunos nodos que modifican o cargan objetos incluyen un campo **Filter** para
+limitar los cambios o instancias según un patrón de nombre o ruta de colección.
 
 Para controlar qué sockets se muestran, selecciona un nodo y abre la barra
 lateral del Node Editor con **N**. En la pestaña **Node** encontrarás el panel

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -91,6 +91,11 @@ def _evaluate_scene_instance(node, _inputs, scene, context):
         if getattr(node, "use_load_mode", False)
         else getattr(node, "load_mode", "APPEND")
     )
+    filter_expr = (
+        _socket_value(node, "Filter", getattr(node, "filter_expr", ""))
+        if getattr(node, "use_filter_expr", False)
+        else getattr(node, "filter_expr", "")
+    )
     if not filepath or not collection_path:
         node.scene_nodes_output = None
         return None
@@ -104,6 +109,13 @@ def _evaluate_scene_instance(node, _inputs, scene, context):
     if collection is None:
         node.scene_nodes_output = None
         return None
+
+    if filter_expr:
+        objs = list(filter_objects(collection.objects, filter_expr))
+        filtered = bpy.data.collections.new(name=f"{collection.name}_filtered")
+        for obj in objs:
+            filtered.objects.link(obj)
+        collection = filtered
 
     if load_mode == "OVERRIDE":
         # Link, create override and remove original link to avoid duplicates

--- a/nodes/scene_instance.py
+++ b/nodes/scene_instance.py
@@ -44,5 +44,6 @@ build_props_and_sockets(
                 "default": "APPEND",
             },
         ),
+        ("filter_expr", "string", {"name": "Filter"}),
     ],
 )

--- a/tests/test_scene_instance.py
+++ b/tests/test_scene_instance.py
@@ -1,0 +1,135 @@
+import types
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Stub Blender modules
+bpy = types.ModuleType("bpy")
+bpy.__path__ = []
+bpy.utils = types.SimpleNamespace(register_class=lambda *a, **k: None,
+                                  unregister_class=lambda *a, **k: None)
+bpy.types = types.ModuleType("bpy.types")
+bpy.props = types.SimpleNamespace(
+    FloatProperty=lambda **k: None,
+    IntProperty=lambda **k: None,
+    BoolProperty=lambda **k: None,
+    FloatVectorProperty=lambda **k: None,
+    StringProperty=lambda **k: None,
+    EnumProperty=lambda **k: None,
+    CollectionProperty=lambda **k: None,
+)
+bpy.types.NodeTree = type("NodeTree", (), {})
+bpy.types.Node = type("Node", (), {})
+bpy.types.NodeSocket = type("NodeSocket", (), {})
+bpy.types.Operator = type("Operator", (), {})
+bpy.types.Panel = type("Panel", (), {})
+bpy.types.PropertyGroup = type("PropertyGroup", (), {})
+bpy.types.UIList = type("UIList", (), {})
+sys.modules.setdefault("bpy", bpy)
+sys.modules.setdefault("bpy.types", bpy.types)
+
+nodeitems_utils = types.ModuleType("nodeitems_utils")
+nodeitems_utils.register_node_categories = lambda *a, **k: None
+nodeitems_utils.unregister_node_categories = lambda *a, **k: None
+nodeitems_utils.NodeCategory = type("NodeCategory", (), {"__init__": lambda self,*a,**k: None})
+nodeitems_utils.NodeItem = lambda *a, **k: None
+sys.modules.setdefault("nodeitems_utils", nodeitems_utils)
+
+mathutils = types.ModuleType("mathutils")
+mathutils.Vector = tuple
+sys.modules.setdefault("mathutils", mathutils)
+
+from scene_nodes.engine import evaluator
+
+class FakeObjects(list):
+    def link(self, obj):
+        self.append(obj)
+    def unlink(self, obj):
+        if obj in self:
+            self.remove(obj)
+
+class FakeCollection:
+    def __init__(self, name):
+        self.name = name
+        self.objects = FakeObjects()
+        self.children = FakeObjects()
+        self.users = 0
+        self.parent = None
+    def override_create(self, parent):
+        # simple stub returning self
+        return self
+
+class FakeScene:
+    def __init__(self):
+        self.collection = FakeCollection("Root")
+
+class FakeLibLoad:
+    def __init__(self, collections):
+        self.collections = collections
+    def __enter__(self):
+        self.data_from = types.SimpleNamespace(collections=list(self.collections.keys()))
+        self.data_to = types.SimpleNamespace(collections=[])
+        return (self.data_from, self.data_to)
+    def __exit__(self, exc_type, exc, tb):
+        self.data_to.collections = [self.collections[name] for name in self.data_to.collections]
+        return False
+
+def make_env(src_collection):
+    bpy.data = types.SimpleNamespace(
+        libraries=types.SimpleNamespace(load=lambda path, link=False: FakeLibLoad({"Coll": src_collection})),
+        collections=types.SimpleNamespace(new=lambda name: FakeCollection(name), get=lambda name: None, remove=lambda coll: None),
+        objects=types.SimpleNamespace(remove=lambda obj, do_unlink=True: None, new=lambda name, object_data=None: types.SimpleNamespace(name=name)),
+    )
+    evaluator.bpy.data = bpy.data
+
+
+def test_scene_instance_no_filter():
+    src = FakeCollection("Coll")
+    a = types.SimpleNamespace(name="A", users_collection=[src])
+    b = types.SimpleNamespace(name="B", users_collection=[src])
+    src.objects.link(a)
+    src.objects.link(b)
+    make_env(src)
+
+    node = types.SimpleNamespace(
+        inputs={},
+        use_file_path=True, file_path="dummy.blend",
+        use_collection_path=True, collection_path="Coll",
+        use_load_mode=True, load_mode="APPEND",
+        use_filter_expr=False, filter_expr="",
+    )
+    scene = FakeScene()
+    ctx = types.SimpleNamespace(render_pass="")
+
+    result = evaluator._evaluate_scene_instance(node, [], scene, ctx)
+
+    assert result is src
+    assert src in scene.collection.children
+
+
+def test_scene_instance_with_filter():
+    src = FakeCollection("Coll")
+    a = types.SimpleNamespace(name="A", users_collection=[src])
+    b = types.SimpleNamespace(name="B", users_collection=[src])
+    src.objects.link(a)
+    src.objects.link(b)
+    make_env(src)
+
+    node = types.SimpleNamespace(
+        inputs={},
+        use_file_path=True, file_path="dummy.blend",
+        use_collection_path=True, collection_path="Coll",
+        use_load_mode=True, load_mode="APPEND",
+        use_filter_expr=True, filter_expr="B*",
+    )
+    scene = FakeScene()
+    ctx = types.SimpleNamespace(render_pass="")
+
+    result = evaluator._evaluate_scene_instance(node, [], scene, ctx)
+
+    assert result is not src
+    assert len(result.objects) == 1
+    assert result.objects[0].name == "B"
+    assert result in scene.collection.children
+


### PR DESCRIPTION
## Summary
- add Filter property to Scene Instance node
- filter loaded objects in `_evaluate_scene_instance`
- document the new Scene Instance filter option
- mention filtering in README
- add tests for Scene Instance filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68510f0fc3988330b652046114546f00