### PR TITLE
Add operator panel to N menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ After enabling, you'll have a new **Scene Graph** tree type in the Node Editor.
 3. Connect them with the provided `Scene` sockets.
 
 The tree can be evaluated via the **Sync to Scene** operator (accessible with **F3**) or from a Python script.
+You can also find shortcuts to this and other operators in the **Scene Nodes**
+tab of the side panel (**N**).
 The operator uses the Scene Graph tree currently open in the Node Editor (or the
 first one it finds in the file) so scenes don't need their own tree pointer.
 When present, **Render** nodes in the tree produce output images during evaluation.

--- a/documentation.txt
+++ b/documentation.txt
@@ -27,6 +27,8 @@ Uso básico
 4. Ejecuta el operador **Sync to Scene** (menú F3) para evaluar el árbol y
    sincronizarlo con la escena de Blender. Los nodos **Render**, si existen,
    producirán una imagen de salida.
+   También puedes acceder a este y otros operadores desde la pestaña
+   **Scene Nodes** en el panel lateral (**N**).
    El operador utiliza el árbol de Scene Graph activo en el Node Editor (o el
    primero que encuentre en el archivo), por lo que las escenas no necesitan
    tener un árbol asignado.
@@ -156,6 +158,8 @@ Flujo de trabajo recomendado
 4. Utiliza **Light** para iluminar.
 5. Si deseas generar una imagen, añade un nodo **Render** al final.
 6. Ejecuta **Sync to Scene** para aplicar y renderizar los cambios.
+   El panel lateral (**N**) incluye accesos directos a los operadores
+   disponibles.
 Ten en cuenta que este complemento sigue siendo experimental, pero ahora la
 evaluación del árbol aplica los cambios directamente en la escena de Blender en
 lugar de limitarse a imprimir información en la consola. Sirve como base para

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -4,6 +4,7 @@ from .node_panel import (
     SCENE_NODES_PT_node_props,
     SCENE_NODES_PT_node_props_properties,
     SCENE_NODES_PT_socket_visibility,
+    SCENE_NODES_PT_operators,
 )
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "SCENE_NODES_PT_node_props",
     "SCENE_NODES_PT_node_props_properties",
     "SCENE_NODES_PT_socket_visibility",
+    "SCENE_NODES_PT_operators",
 ]
 from . import node_panel
 

--- a/ui/node_panel.py
+++ b/ui/node_panel.py
@@ -81,6 +81,24 @@ class SCENE_NODES_PT_socket_visibility(bpy.types.Panel):
                         row.prop(sock, "value", text="")
 
 
+class SCENE_NODES_PT_operators(bpy.types.Panel):
+    """Panel with quick access to Scene Node operators."""
+    bl_idname = "SCENE_NODES_PT_operators"
+    bl_label = "Scene Node Operators"
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'UI'
+    bl_category = 'Scene Nodes'
+
+    @classmethod
+    def poll(cls, context):
+        return context.space_data.tree_type == 'SceneNodeTreeType'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("scene_nodes.sync_to_scene")
+        layout.operator("scene_nodes.render_pass_wedge")
+
+
 class SCENE_NODES_PT_node_props_properties(SCENE_NODES_PT_node_props):
     bl_idname = "SCENE_NODES_PT_node_props_properties"
     bl_space_type = 'PROPERTIES'
@@ -90,9 +108,11 @@ def register():
     bpy.utils.register_class(SCENE_NODES_PT_node_props)
     bpy.utils.register_class(SCENE_NODES_PT_node_props_properties)
     bpy.utils.register_class(SCENE_NODES_PT_socket_visibility)
+    bpy.utils.register_class(SCENE_NODES_PT_operators)
 
 
 def unregister():
     bpy.utils.unregister_class(SCENE_NODES_PT_socket_visibility)
+    bpy.utils.unregister_class(SCENE_NODES_PT_operators)
     bpy.utils.unregister_class(SCENE_NODES_PT_node_props_properties)
     bpy.utils.unregister_class(SCENE_NODES_PT_node_props)


### PR DESCRIPTION
## Summary
- add **Scene Node Operators** panel with Sync and Render Pass buttons
- export panel via ui package
- document new N panel in documentation and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685189b6e4908330af79f2fdca718e4f