### PR TITLE
Fix duplicate import of EnumSocket

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,7 +21,6 @@ from .nodes.base import (
     VectorSocket,
     StringSocket,
     EnumSocket,
-    EnumSocket,
 )
 
 # Nodos individuales


### PR DESCRIPTION
## Summary
- remove duplicate `EnumSocket` import from `__init__.py`
- keep single `EnumSocket` entry in `classes`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d5e3f5888330b168583b45c178de