### PR TITLE
Fix render pass wedge context

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ tree.links.new(props.outputs[0], render.inputs[0])
 
 # Evaluate the tree (applies changes to the scene)
 evaluate_scene_tree(tree)
+
+# You can also specify a render pass name when evaluating without
+# a Render node
+# evaluate_scene_tree(tree, render_pass="MyPass")
 ```
 
 Nodes that modify or load objects, such as **Transform**, **Cycles Attributes**

--- a/documentation.txt
+++ b/documentation.txt
@@ -38,6 +38,8 @@ También es posible evaluar el arbol mediante Python con:
 ```python
 from scene_nodes.engine import evaluate_scene_tree
 evaluate_scene_tree(mi_tree)
+# O especificar el nombre del render pass
+# evaluate_scene_tree(mi_tree, render_pass="MiPass")
 ```
 
 Nodos disponibles

--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -641,8 +641,16 @@ def _evaluate_node(node, scene, context):
         print(f"[scene_nodes] unknown node type {ntype}")
 
 
-def evaluate_scene_tree(tree):
-    """Evaluate *tree* and execute Render nodes when present."""
+def evaluate_scene_tree(tree, render_pass="Scene"):
+    """Evaluate *tree* and execute Render nodes when present.
+
+    Parameters
+    ----------
+    tree : NodeTree
+        The scene node tree to evaluate.
+    render_pass : str, optional
+        Name of the active render pass when no Render nodes are present.
+    """
     if tree is None:
         raise ValueError("Scene node tree is None")
 
@@ -656,16 +664,16 @@ def evaluate_scene_tree(tree):
                     rnode,
                     "Name",
                     getattr(rnode, "scene_name", ""),
-                ) or "Scene"
+                ) or render_pass
             else:
-                context.render_pass = "Scene"
+                context.render_pass = render_pass
             scene = _prepare_scene()
             order = _topological_sort([rnode])
             for node in order:
                 node.scene_nodes_output = _evaluate_node(node, scene, context)
             bpy.ops.render.render(write_still=True)
     else:
-        context = types.SimpleNamespace(render_pass="Scene")
+        context = types.SimpleNamespace(render_pass=render_pass)
         scene = _prepare_scene()
         order = _topological_sort(list(tree.nodes))
         for node in order:

--- a/tests/test_render_pass_wedge.py
+++ b/tests/test_render_pass_wedge.py
@@ -65,7 +65,7 @@ class FakeScene:
 
 evaluated_scenes = []
 
-def fake_evaluate_scene_tree(tree):
+def fake_evaluate_scene_tree(tree, render_pass="Scene"):
     scene = FakeScene()
     evaluated_scenes.append(scene)
     bpy.context.window.scene = scene

--- a/ui/operators.py
+++ b/ui/operators.py
@@ -68,8 +68,7 @@ class RENDER_OT_render_pass_wedge(bpy.types.Operator):
         original_layer = context.window.view_layer
 
         for item in passes_node.passes:
-            setattr(context, "render_pass", item.name)
-            evaluate_scene_tree(tree)
+            evaluate_scene_tree(tree, render_pass=item.name)
 
             scene = bpy.context.window.scene
             layer = scene.view_layers.get(item.name)


### PR DESCRIPTION
## Summary
- support specifying `render_pass` when evaluating a scene tree
- use the new argument from `RENDER_OT_render_pass_wedge`
- adjust tests for the new signature
- document the optional parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e72faebc8330b1ca79c7f3257687