### PR TITLE
Add comprehensive render properties

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -374,6 +374,38 @@ def _evaluate_cycles_properties(node, _inputs, scene, context):
     if getattr(node, "use_max_bounces", False):
         scene.cycles.max_bounces = _socket_value(node, "Max Bounces", getattr(node, "max_bounces", 8))
 
+    if getattr(node, "use_diffuse_bounces", False):
+        scene.cycles.diffuse_bounces = _socket_value(node, "Diffuse Bounces", getattr(node, "diffuse_bounces", 4))
+
+    if getattr(node, "use_adaptive_sampling", False):
+        scene.cycles.use_adaptive_sampling = _socket_value(node, "Adaptive Sampling", getattr(node, "use_adaptive_sampling", False))
+
+    if getattr(node, "use_volume_step_rate", False):
+        scene.cycles.volume_step_rate = _socket_value(node, "Volume Step Rate", getattr(node, "volume_step_rate", 1.0))
+
+    if getattr(node, "use_hair_shape_radius", False):
+        scene.cycles.hair_shape_radius = _socket_value(node, "Hair Shape Radius", getattr(node, "hair_shape_radius", 1.0))
+
+    if getattr(node, "use_simplify", False):
+        scene.render.use_simplify = _socket_value(node, "Use Simplify", getattr(node, "use_simplify", False))
+
+    if getattr(node, "use_motion_blur_shutter", False):
+        scene.render.motion_blur_shutter = _socket_value(node, "Shutter", getattr(node, "motion_blur_shutter", 0.5))
+
+    if getattr(node, "use_film_exposure", False):
+        scene.cycles.film_exposure = _socket_value(node, "Exposure", getattr(node, "film_exposure", 1.0))
+
+    if getattr(node, "use_tile_x", False):
+        scene.cycles.tile_x = _socket_value(node, "Tile X", getattr(node, "tile_x", 64))
+
+    if getattr(node, "use_gpencil_antialias_threshold", False):
+        gp = getattr(scene, "grease_pencil", types.SimpleNamespace(antialias_threshold=1.0))
+        gp.antialias_threshold = _socket_value(node, "Grease Pencil AA", getattr(node, "gpencil_antialias_threshold", 1.0))
+        scene.grease_pencil = gp
+
+    if getattr(node, "use_use_freestyle", False):
+        scene.render.use_freestyle = _socket_value(node, "Use Freestyle", getattr(node, "use_freestyle", False))
+
     if getattr(node, "use_filepath", False):
         scene.render.filepath = _socket_value(node, "File Path", getattr(node, "filepath", ""))
 
@@ -413,8 +445,26 @@ def _evaluate_eevee_properties(node, _inputs, scene, context):
     if getattr(node, "use_samples", False):
         scene.eevee.taa_render_samples = _socket_value(node, "Samples", getattr(node, "samples", 64))
 
+    if getattr(node, "use_use_taa_reprojection", False):
+        scene.eevee.use_taa_reprojection = _socket_value(node, "TAA Reprojection", getattr(node, "use_taa_reprojection", False))
+
+    if getattr(node, "use_clamp_direct", False):
+        scene.eevee.clamp_direct = _socket_value(node, "Clamp Direct", getattr(node, "clamp_direct", 0.0))
+
+    if getattr(node, "use_clamp_indirect", False):
+        scene.eevee.clamp_indirect = _socket_value(node, "Clamp Indirect", getattr(node, "clamp_indirect", 0.0))
+
+    if getattr(node, "use_raytrace_resolution", False):
+        scene.eevee.raytrace_resolution = _socket_value(node, "Raytrace Resolution", getattr(node, "raytrace_resolution", 512))
+
     if getattr(node, "use_motion_blur", False):
         scene.eevee.use_motion_blur = _socket_value(node, "Motion Blur", getattr(node, "motion_blur", False))
+
+    if getattr(node, "use_motion_blur_shutter", False):
+        scene.eevee.motion_blur_shutter = _socket_value(node, "Shutter", getattr(node, "motion_blur_shutter", 0.5))
+
+    if getattr(node, "use_film_exposure", False):
+        scene.eevee.film_exposure = _socket_value(node, "Exposure", getattr(node, "film_exposure", 1.0))
 
     if getattr(node, "use_filepath", False):
         scene.render.filepath = _socket_value(node, "File Path", getattr(node, "filepath", ""))

--- a/nodes/cycles_properties.py
+++ b/nodes/cycles_properties.py
@@ -18,14 +18,13 @@ class CyclesPropertiesNode(BaseNode):
 build_props_and_sockets(
     CyclesPropertiesNode,
     [
+        # General Output
         ("res_x", "int", {"name": "Resolution X", "default": 1920}),
         ("res_y", "int", {"name": "Resolution Y", "default": 1080}),
         ("frame_start", "int", {"name": "Frame Start", "default": 1}),
         ("frame_end", "int", {"name": "Frame End", "default": 250}),
         ("fps", "int", {"name": "FPS", "default": 24}),
         ("camera_path", "string", {"name": "Camera Path"}),
-        ("samples", "int", {"name": "Samples", "default": 64}),
-        ("max_bounces", "int", {"name": "Max Bounces", "default": 8}),
         ("filepath", "string", {"name": "File Path", "subtype": "FILE_PATH"}),
         (
             "file_format",
@@ -51,5 +50,37 @@ build_props_and_sockets(
                 "default": "RGB",
             },
         ),
+
+        # Sampling
+        ("samples", "int", {"name": "Samples", "default": 64}),
+        ("use_adaptive_sampling", "bool", {"name": "Adaptive Sampling"}),
+
+        # Light Paths
+        ("max_bounces", "int", {"name": "Max Bounces", "default": 8}),
+        ("diffuse_bounces", "int", {"name": "Diffuse Bounces", "default": 4}),
+
+        # Volumes
+        ("volume_step_rate", "float", {"name": "Volume Step Rate", "default": 1.0}),
+
+        # Curves
+        ("hair_shape_radius", "float", {"name": "Hair Shape Radius", "default": 1.0}),
+
+        # Simplify
+        ("use_simplify", "bool", {"name": "Use Simplify"}),
+
+        # Motion Blur
+        ("motion_blur_shutter", "float", {"name": "Shutter", "default": 0.5}),
+
+        # Film
+        ("film_exposure", "float", {"name": "Exposure", "default": 1.0}),
+
+        # Performance
+        ("tile_x", "int", {"name": "Tile X", "default": 64}),
+
+        # Grease Pencil
+        ("gpencil_antialias_threshold", "float", {"name": "Grease Pencil AA", "default": 1.0}),
+
+        # Freestyle
+        ("use_freestyle", "bool", {"name": "Use Freestyle"}),
     ],
 )

--- a/nodes/eevee_properties.py
+++ b/nodes/eevee_properties.py
@@ -18,14 +18,13 @@ class EeveePropertiesNode(BaseNode):
 build_props_and_sockets(
     EeveePropertiesNode,
     [
+        # General Output
         ("res_x", "int", {"name": "Resolution X", "default": 1920}),
         ("res_y", "int", {"name": "Resolution Y", "default": 1080}),
         ("frame_start", "int", {"name": "Frame Start", "default": 1}),
         ("frame_end", "int", {"name": "Frame End", "default": 250}),
         ("fps", "int", {"name": "FPS", "default": 24}),
         ("camera_path", "string", {"name": "Camera Path"}),
-        ("samples", "int", {"name": "Samples", "default": 64}),
-        ("motion_blur", "bool", {"name": "Motion Blur"}),
         ("filepath", "string", {"name": "File Path", "subtype": "FILE_PATH"}),
         (
             "file_format",
@@ -51,5 +50,23 @@ build_props_and_sockets(
                 "default": "RGB",
             },
         ),
+
+        # Sampling
+        ("samples", "int", {"name": "Samples", "default": 64}),
+        ("use_taa_reprojection", "bool", {"name": "TAA Reprojection"}),
+
+        # Clamping
+        ("clamp_direct", "float", {"name": "Clamp Direct", "default": 0.0}),
+        ("clamp_indirect", "float", {"name": "Clamp Indirect", "default": 0.0}),
+
+        # Raytracing
+        ("raytrace_resolution", "int", {"name": "Raytrace Resolution", "default": 512}),
+
+        # Motion Blur
+        ("motion_blur", "bool", {"name": "Motion Blur"}),
+        ("motion_blur_shutter", "float", {"name": "Shutter", "default": 0.5}),
+
+        # Film
+        ("film_exposure", "float", {"name": "Exposure", "default": 1.0}),
     ],
 )

--- a/tests/test_properties_nodes.py
+++ b/tests/test_properties_nodes.py
@@ -54,11 +54,33 @@ class FakeScene:
             filepath="",
             fps=24,
             image_settings=types.SimpleNamespace(file_format="", color_mode=""),
+            use_simplify=False,
+            motion_blur_shutter=0.0,
+            use_freestyle=False,
         )
         self.frame_start = 1
         self.frame_end = 250
-        self.cycles = types.SimpleNamespace(samples=0, max_bounces=0)
-        self.eevee = types.SimpleNamespace(taa_render_samples=0, use_motion_blur=False)
+        self.cycles = types.SimpleNamespace(
+            samples=0,
+            max_bounces=0,
+            diffuse_bounces=0,
+            use_adaptive_sampling=False,
+            volume_step_rate=1.0,
+            hair_shape_radius=0.0,
+            film_exposure=1.0,
+            tile_x=0,
+        )
+        self.eevee = types.SimpleNamespace(
+            taa_render_samples=0,
+            use_motion_blur=False,
+            use_taa_reprojection=False,
+            clamp_direct=0.0,
+            clamp_indirect=0.0,
+            raytrace_resolution=0,
+            motion_blur_shutter=0.0,
+            film_exposure=1.0,
+        )
+        self.grease_pencil = types.SimpleNamespace(antialias_threshold=1.0)
         self.collection = object()
         self.camera = None
 
@@ -74,6 +96,16 @@ def test_cycles_properties():
         use_camera_path=False,
         use_samples=True, samples=16,
         use_max_bounces=True, max_bounces=4,
+        use_use_adaptive_sampling=True, use_adaptive_sampling=True,
+        use_diffuse_bounces=True, diffuse_bounces=2,
+        use_volume_step_rate=True, volume_step_rate=0.5,
+        use_hair_shape_radius=True, hair_shape_radius=1.5,
+        use_use_simplify=True, use_simplify=True,
+        use_motion_blur_shutter=True, motion_blur_shutter=0.4,
+        use_film_exposure=True, film_exposure=1.2,
+        use_tile_x=True, tile_x=32,
+        use_gpencil_antialias_threshold=True, gpencil_antialias_threshold=0.2,
+        use_use_freestyle=True, use_freestyle=True,
         use_filepath=True, filepath="/tmp/a",
         use_file_format=True, file_format="PNG",
         use_color_mode=True, color_mode="RGBA",
@@ -90,6 +122,16 @@ def test_cycles_properties():
     assert scene.render.fps == 30
     assert scene.cycles.samples == 16
     assert scene.cycles.max_bounces == 4
+    assert scene.cycles.diffuse_bounces == 2
+    assert scene.cycles.use_adaptive_sampling is True
+    assert scene.cycles.volume_step_rate == 0.5
+    assert scene.cycles.hair_shape_radius == 1.5
+    assert scene.render.use_simplify is True
+    assert scene.render.motion_blur_shutter == 0.4
+    assert scene.cycles.film_exposure == 1.2
+    assert scene.cycles.tile_x == 32
+    assert scene.grease_pencil.antialias_threshold == 0.2
+    assert scene.render.use_freestyle is True
     assert scene.render.filepath == "/tmp/a"
     assert scene.render.image_settings.file_format == "PNG"
     assert scene.render.image_settings.color_mode == "RGBA"
@@ -105,7 +147,13 @@ def test_eevee_properties():
         use_fps=True, fps=60,
         use_camera_path=False,
         use_samples=True, samples=8,
+        use_use_taa_reprojection=True, use_taa_reprojection=True,
+        use_clamp_direct=True, clamp_direct=0.1,
+        use_clamp_indirect=True, clamp_indirect=0.2,
+        use_raytrace_resolution=True, raytrace_resolution=256,
         use_motion_blur=True, motion_blur=True,
+        use_motion_blur_shutter=True, motion_blur_shutter=0.3,
+        use_film_exposure=True, film_exposure=1.1,
         use_filepath=True, filepath="/tmp/b",
         use_file_format=True, file_format="OPEN_EXR",
         use_color_mode=True, color_mode="RGB",
@@ -121,7 +169,14 @@ def test_eevee_properties():
     assert scene.frame_end == 15
     assert scene.render.fps == 60
     assert scene.eevee.taa_render_samples == 8
+    assert scene.eevee.use_taa_reprojection is True
+    assert scene.eevee.clamp_direct == 0.1
+    assert scene.eevee.clamp_indirect == 0.2
+    assert scene.eevee.raytrace_resolution == 256
     assert scene.eevee.use_motion_blur is True
+    assert scene.eevee.motion_blur_shutter == 0.3
+    assert scene.eevee.film_exposure == 1.1
     assert scene.render.filepath == "/tmp/b"
     assert scene.render.image_settings.file_format == "OPEN_EXR"
     assert scene.render.image_settings.color_mode == "RGB"
+


### PR DESCRIPTION
## Summary
- expand Cycles and Eevee properties nodes with render options grouped by category
- apply the new properties when evaluating node trees
- broaden property tests to cover the new categories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685265eafc708330a9c0f1be2f7e7823