### PR TITLE
Fix render pass wedge context handling

### DIFF
--- a/engine/evaluator.py
+++ b/engine/evaluator.py
@@ -641,8 +641,17 @@ def _evaluate_node(node, scene, context):
         print(f"[scene_nodes] unknown node type {ntype}")
 
 
-def evaluate_scene_tree(tree):
-    """Evaluate *tree* and execute Render nodes when present."""
+def evaluate_scene_tree(tree, render_pass="Scene"):
+    """Evaluate *tree* and execute Render nodes when present.
+
+    Parameters
+    ----------
+    tree : NodeTree
+        Scene node tree to evaluate.
+    render_pass : str, optional
+        Name of the render pass used when a ``RenderPasses`` node is driving
+        the evaluation. Defaults to ``"Scene"``.
+    """
     if tree is None:
         raise ValueError("Scene node tree is None")
 
@@ -656,16 +665,16 @@ def evaluate_scene_tree(tree):
                     rnode,
                     "Name",
                     getattr(rnode, "scene_name", ""),
-                ) or "Scene"
+                ) or render_pass
             else:
-                context.render_pass = "Scene"
+                context.render_pass = render_pass
             scene = _prepare_scene()
             order = _topological_sort([rnode])
             for node in order:
                 node.scene_nodes_output = _evaluate_node(node, scene, context)
             bpy.ops.render.render(write_still=True)
     else:
-        context = types.SimpleNamespace(render_pass="Scene")
+        context = types.SimpleNamespace(render_pass=render_pass)
         scene = _prepare_scene()
         order = _topological_sort(list(tree.nodes))
         for node in order:

--- a/tests/test_render_pass_wedge.py
+++ b/tests/test_render_pass_wedge.py
@@ -65,7 +65,7 @@ class FakeScene:
 
 evaluated_scenes = []
 
-def fake_evaluate_scene_tree(tree):
+def fake_evaluate_scene_tree(tree, render_pass="Scene"):
     scene = FakeScene()
     evaluated_scenes.append(scene)
     bpy.context.window.scene = scene

--- a/ui/operators.py
+++ b/ui/operators.py
@@ -68,8 +68,7 @@ class RENDER_OT_render_pass_wedge(bpy.types.Operator):
         original_layer = context.window.view_layer
 
         for item in passes_node.passes:
-            setattr(context, "render_pass", item.name)
-            evaluate_scene_tree(tree)
+            evaluate_scene_tree(tree, item.name)
 
             scene = bpy.context.window.scene
             layer = scene.view_layers.get(item.name)


### PR DESCRIPTION
## Summary
- pass the intended render pass name directly into `evaluate_scene_tree`
- avoid setting attributes on Blender's context which is read-only
- adjust evaluator to accept optional `render_pass` parameter
- update tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e72faebc8330b1ca79c7f3257687